### PR TITLE
Darcy.rayner/fix global runtime error

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^24.0.13",
     "@types/mock-fs": "true3.6.30",
     "@types/node": "^12.0.4",
-    "@types/serverless": "true1.18.2",
+    "@types/serverless": "true1.18.3",
     "jest": "^24.8.0",
     "mock-fs": "true4.10.1",
     "nock": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import * as Serverless from "serverless";
 import * as layers from "./layers.json";
 
 import { getConfig, setEnvConfiguration } from "./env";
-import { applyLayers, findHandlers } from "./layer";
+import { applyLayers, findHandlers, findGlobalRuntime } from "./layer";
 import { enabledTracing } from "./tracing";
 import { cleanupHandlers, writeHandlers } from "./wrapper";
 
@@ -50,8 +50,8 @@ module.exports = class ServerlessPlugin {
     this.serverless.cli.log("Auto instrumenting functions with Datadog");
     const config = getConfig(this.serverless.service);
     setEnvConfiguration(config, this.serverless.service);
-
-    const handlers = findHandlers(this.serverless.service);
+    const defaultRuntime = this.serverless.service.provider.runtime;
+    const handlers = findHandlers(this.serverless.service, defaultRuntime);
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Layers to functions");
       applyLayers(this.serverless.service.provider.region, handlers, layers);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import * as Serverless from "serverless";
 import * as layers from "./layers.json";
 
 import { getConfig, setEnvConfiguration } from "./env";
-import { applyLayers, findHandlers, RuntimeType, HandlerInfo } from "./layer";
+import { applyLayers, findHandlers, HandlerInfo, RuntimeType } from "./layer";
 import { enabledTracing } from "./tracing";
 import { cleanupHandlers, writeHandlers } from "./wrapper";
 

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -37,22 +37,40 @@ describe("findHandlers", () => {
       {
         handler: { runtime: "nodejs8.10" },
         type: RuntimeType.NODE,
+        runtime: "nodejs8.10",
       },
       {
         handler: { runtime: "nodejs10.x" },
         type: RuntimeType.NODE,
+        runtime: "nodejs10.x",
       },
       {
         handler: { runtime: "python2.7" },
         type: RuntimeType.PYTHON,
+        runtime: "python2.7",
       },
       {
         handler: { runtime: "python3.6" },
         type: RuntimeType.PYTHON,
+        runtime: "python3.6",
       },
       {
         handler: { runtime: "python3.7" },
         type: RuntimeType.PYTHON,
+        runtime: "python3.7",
+      },
+    ]);
+  });
+  it("uses the global runtime when one isn't specified", () => {
+    const mockService = createMockService("us-east-1", {
+      "func-a": {},
+    });
+    const result = findHandlers(mockService, "nodejs8.10");
+    expect(result).toMatchObject([
+      {
+        handler: {},
+        type: RuntimeType.NODE,
+        runtime: "nodejs8.10",
       },
     ]);
   });
@@ -63,6 +81,7 @@ describe("applyLayers", () => {
     const handler = {
       handler: { runtime: "nodejs10.x" },
       type: RuntimeType.NODE,
+      runtime: "nodejs10.x",
     } as HandlerInfo;
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:2" } },
@@ -77,6 +96,7 @@ describe("applyLayers", () => {
     const handler = {
       handler: { runtime: "nodejs10.x", layers: ["node:1"] } as any,
       type: RuntimeType.NODE,
+      runtime: "nodejs10.x",
     } as HandlerInfo;
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:2" } },
@@ -91,6 +111,7 @@ describe("applyLayers", () => {
     const handler = {
       handler: { runtime: "nodejs10.x", layers: ["node:1"] } as any,
       type: RuntimeType.NODE,
+      runtime: "nodejs10.x",
     } as HandlerInfo;
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:1" } },
@@ -105,6 +126,7 @@ describe("applyLayers", () => {
     const handler = {
       handler: { runtime: "nodejs10.x" } as any,
       type: RuntimeType.NODE,
+      runtime: "nodejs10.x",
     } as HandlerInfo;
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:1" } },
@@ -118,6 +140,7 @@ describe("applyLayers", () => {
     const handler = {
       handler: { runtime: "nodejs10.x" } as any,
       type: RuntimeType.NODE,
+      runtime: "nodejs10.x",
     } as HandlerInfo;
     const layers: LayerJSON = {
       regions: { "us-east-1": { "python2.7": "python:2" } },
@@ -131,6 +154,7 @@ describe("applyLayers", () => {
     const handler = {
       handler: {} as any,
       type: RuntimeType.NODE,
+      runtime: "nodejs10.x",
     } as HandlerInfo;
     const layers: LayerJSON = {
       regions: { "us-east-1": { "python2.7": "python:2" } },

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -40,6 +40,11 @@ describe("findHandlers", () => {
         runtime: "nodejs8.10",
       },
       {
+        handler: { runtime: "go1.10" },
+        type: RuntimeType.UNSUPPORTED,
+        runtime: "go1.10",
+      },
+      {
         handler: { runtime: "nodejs10.x" },
         type: RuntimeType.NODE,
         runtime: "nodejs10.x",
@@ -155,6 +160,17 @@ describe("applyLayers", () => {
       handler: {} as any,
       type: RuntimeType.NODE,
       runtime: "nodejs10.x",
+    } as HandlerInfo;
+    const layers: LayerJSON = {
+      regions: { "us-east-1": { "python2.7": "python:2" } },
+    };
+    applyLayers("us-east-1", [handler], layers);
+    expect(handler.handler).toEqual({});
+  });
+  it("only add layer when when supported runtime present", () => {
+    const handler = {
+      handler: {} as any,
+      type: RuntimeType.UNSUPPORTED,
     } as HandlerInfo;
     const layers: LayerJSON = {
       regions: { "us-east-1": { "python2.7": "python:2" } },

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,10 +367,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
 
-"@types/serverless@true1.18.2":
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/@types/serverless/-/serverless-1.18.2.tgz#4054abce878bc4e29896c005cb8e88563fd0e4fc"
-  integrity sha512-bBbuNQkDUYZFjmT4KB/eiFKyoNbTcnSslVpeKH+3j1C9xhIkSS1sEZtiFb0TI9TnalxauGEnZRmQ0c6uzAY2Zg==
+"@types/serverless@true1.18.3":
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/@types/serverless/-/serverless-1.18.3.tgz#ac2fac6240b12fff587daaa05dd20b679e3ea534"
+  integrity sha512-8wrTc80rIhQWK3YHQOAQjYlZByeWhe8gtMn5bOedXdT2M8SyAYVeZIio1+pQIma1qbIpwg6H3YKkKDuJDLf36g==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where the plugin was ignoring the provider.runtime value, when runtime is missing from the function definition

eg The following serverless.yml worked

```yml
# ...
provider:
  name: aws
# ...
functions:
  hello10x:
    runtime: nodejs10.x # Recognized
    handler: handler.hello
    events: # ...
```

But this didn't

```yml
# ...
provider:
  name: aws
  runtime: nodejs10.x # Not recognized
# ...
functions:
  hello10x:
    handler: handler.hello
    events: # ...
```