### PR TITLE
Bump version to 0.6.0 to pick up new Python and Node layer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",


### PR DESCRIPTION
### What does this PR do?

Bumping the version so that the new Python and Node layer versions from https://github.com/DataDog/datadog-lambda-layer-python/pull/19 and https://github.com/DataDog/datadog-lambda-layer-js/pull/28 will be added with the plugin

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
