### PR TITLE
Bump plugin version to 0.7.0 to pick up new Python and Node layer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",


### PR DESCRIPTION
### What does this PR do?

Bump version so that the plugin will add the latest Python and Node layer versions implemented in https://github.com/DataDog/datadog-lambda-layer-python/pull/25 and https://github.com/DataDog/datadog-lambda-layer-js/pull/31