### PR TITLE
Add new lambda runtimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -9,8 +9,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node8-10" "Datadog-Node10-x" "Datadog-Python27" "Datadog-Python36" "Datadog-Python37")
-JSON_LAYER_NAMES=("nodejs8.10" "nodejs10.x" "python2.7" "python3.6" "python3.7")
+LAYER_NAMES=("Datadog-Node8-10" "Datadog-Node10-x" "Datadog-Node12-x" "Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
+JSON_LAYER_NAMES=("nodejs8.10" "nodejs10.x" "nodejs12.x" "python2.7" "python3.6" "python3.7" "python3.8")
 AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
 
 INPUT_JSON="{\"regions\":{}}"

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -30,6 +30,8 @@ describe("findHandlers", () => {
       "func-d": { runtime: "python2.7" },
       "func-e": { runtime: "python3.6" },
       "func-f": { runtime: "python3.7" },
+      "func-g": { runtime: "python3.8" },
+      "func-h": { runtime: "nodejs12.x" },
     });
 
     const result = findHandlers(mockService);
@@ -63,6 +65,16 @@ describe("findHandlers", () => {
         handler: { runtime: "python3.7" },
         type: RuntimeType.PYTHON,
         runtime: "python3.7",
+      },
+      {
+        handler: { runtime: "python3.8" },
+        type: RuntimeType.PYTHON,
+        runtime: "python3.8",
+      },
+      {
+        handler: { runtime: "nodejs12.x" },
+        type: RuntimeType.NODE,
+        runtime: "nodejs12.x",
       },
     ]);
   });

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -34,8 +34,8 @@ export interface LayerJSON {
 
 export const runtimeLookup: { [key: string]: RuntimeType } = {
   "nodejs10.x": RuntimeType.NODE,
-  "nodejs8.10": RuntimeType.NODE,
   "nodejs12.x": RuntimeType.NODE,
+  "nodejs8.10": RuntimeType.NODE,
   "python2.7": RuntimeType.PYTHON,
   "python3.6": RuntimeType.PYTHON,
   "python3.7": RuntimeType.PYTHON,

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -35,9 +35,11 @@ export interface LayerJSON {
 export const runtimeLookup: { [key: string]: RuntimeType } = {
   "nodejs10.x": RuntimeType.NODE,
   "nodejs8.10": RuntimeType.NODE,
+  "nodejs12.x": RuntimeType.NODE,
   "python2.7": RuntimeType.PYTHON,
   "python3.6": RuntimeType.PYTHON,
   "python3.7": RuntimeType.PYTHON,
+  "python3.8": RuntimeType.PYTHON,
 };
 
 export function findHandlers(service: Service, defaultRuntime?: string): HandlerInfo[] {


### PR DESCRIPTION
### What does this PR do?

Adds node 12, python 3.8 runtimes to support list. Waiting for python node layers to be updated before merging.