### PR TITLE
Use path.posix.join when re-writing the handler path

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -28,7 +28,7 @@ export async function writeHandlers(service: Service, handlers: HandlerInfo[]) {
     }
     const { text, method } = result;
     const filename = await writeWrapperFunction(handlerInfo, text);
-    handlerInfo.handler.handler = `${path.join(datadogDirectory, handlerInfo.name)}.${method}`;
+    handlerInfo.handler.handler = `${path.posix.join(datadogDirectory, handlerInfo.name)}.${method}`;
     if (handlerInfo.handler.package === undefined) {
       handlerInfo.handler.package = {
         exclude: [],


### PR DESCRIPTION
Use path.posix.join when re-writing the handler path to enable use from Windows

*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Attempted fix for https://github.com/DataDog/serverless-plugin-datadog/issues/14

### Motivation

https://github.com/DataDog/serverless-plugin-datadog/issues/14

### Testing Guidelines

~It's untested~ Modified 0.9.0 on-disk in my environment and deployed the function with it that I was using when I encountered https://github.com/DataDog/serverless-plugin-datadog/issues/14 and then re-deployed / tested the function and didn't encounter the error from https://github.com/DataDog/serverless-plugin-datadog/issues/14

### Additional Notes

Anything else we should know when reviewing?
