### PR TITLE
Bump plugin version to 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",


### PR DESCRIPTION
### What does this PR do?

Bumps version to release Node layer v0.14.0 implemented in https://github.com/DataDog/datadog-lambda-layer-js/pull/48

