### PR TITLE
Bump plugin version to 0.14.0 to pick up new Node and Python layer versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",


### PR DESCRIPTION
### What does this PR do?

Bumps the plugin version so that the new layer versions from https://github.com/DataDog/datadog-lambda-layer-python/pull/43 and https://github.com/DataDog/datadog-lambda-layer-js/pull/50 will be used by the plugin.