### PR TITLE
Bump package version to 0.15.0 to pick up new Node layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",


### PR DESCRIPTION
### What does this PR do?

Bumps version to pick up the new version of the Node layer from https://github.com/DataDog/datadog-lambda-layer-js/pull/52