### PR TITLE
Bump package version to 0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-datadog",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Serverless plugin to automatically instrument python and node functions with datadog tracing",
   "main": "dist/index.js",
   "repository": "https://github.com/DataDog/serverless-plugin-datadog",


### PR DESCRIPTION
### What does this PR do?

Bump version to 0.21.0 to pick up these changes https://github.com/DataDog/datadog-lambda-layer-js/pull/68
