### PR TITLE
Automatically tagging service and env

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -31,6 +31,7 @@ describe("getConfig", () => {
       site: "datadoghq.com",
       enableXrayTracing: true,
       enableDDTracing: true,
+      enableTags: true,
     });
   });
 });

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -50,6 +50,7 @@ describe("setEnvConfiguration", () => {
         flushMetricsToLogs: true,
         enableXrayTracing: true,
         enableDDTracing: true,
+        enableTags: true,
       },
       service,
     );
@@ -88,6 +89,7 @@ describe("setEnvConfiguration", () => {
         flushMetricsToLogs: false,
         enableXrayTracing: true,
         enableDDTracing: true,
+        enableTags: true,
       },
       service,
     );

--- a/src/env.ts
+++ b/src/env.ts
@@ -31,6 +31,10 @@ export interface Configuration {
 
   // When set, the plugin will subscribe the lambdas to the forwarder with the given arn.
   forwarder?: string;
+
+  // When set, the plugin wiill try to automatically tag customers' lambda functions with service and env,
+  // but will not override existing tags. Defaults to true
+  enableTags: boolean;
 }
 
 const apiKeyEnvVar = "DD_API_KEY";
@@ -46,6 +50,7 @@ export const defaultConfiguration: Configuration = {
   site: "datadoghq.com",
   enableXrayTracing: true,
   enableDDTracing: true,
+  enableTags: true,
 };
 
 export function setEnvConfiguration(config: Configuration, service: Service) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -32,7 +32,7 @@ export interface Configuration {
   // When set, the plugin will subscribe the lambdas to the forwarder with the given arn.
   forwarder?: string;
 
-  // When set, the plugin wiill try to automatically tag customers' lambda functions with service and env,
+  // When set, the plugin will try to automatically tag customers' lambda functions with service and env,
   // but will not override existing tags. Defaults to true
   enableTags: boolean;
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -13,7 +13,7 @@ import fs from "fs";
 import mock from "mock-fs";
 import Aws from "serverless/plugins/aws/provider/awsProvider";
 import { FunctionDefinition } from "serverless";
-import { FunctionDefinitionWithTags } from "./index"
+import { FunctionDefinitionWithTags } from "./index";
 
 function awsMock(): Aws {
   return {
@@ -176,9 +176,9 @@ describe("ServerlessPlugin", () => {
           "handler-2.js": "also-content",
         },
       });
-      const serverless = { 
-        cli: { log: () => {} }, 
-        service: { custom: {}, getAllFunctions: () => [] } 
+      const serverless = {
+        cli: { log: () => {} },
+        service: { custom: {}, getAllFunctions: () => [] },
       };
       const plugin = new ServerlessPlugin(serverless, {});
       await plugin.hooks["after:package:createDeploymentArtifacts"]();
@@ -232,7 +232,7 @@ describe("ServerlessPlugin", () => {
           "handler-2.js": "also-content",
         },
       });
-      const function_ = functionMock({ "env": "test" });
+      const function_ = functionMock({ env: "test" });
       const functionWithTags: FunctionDefinitionWithTags = function_;
       const serverless = {
         cli: { log: () => {} },
@@ -250,7 +250,7 @@ describe("ServerlessPlugin", () => {
       };
       const plugin = new ServerlessPlugin(serverless, {});
       await plugin.hooks["after:package:createDeploymentArtifacts"]();
-      expect(functionWithTags).toHaveProperty("tags", { "env": "test" });
+      expect(functionWithTags).toHaveProperty("tags", { env: "test" });
     });
 
     it("adds tags by default with service name and stage values", async () => {
@@ -273,7 +273,7 @@ describe("ServerlessPlugin", () => {
       };
       const plugin = new ServerlessPlugin(serverless, {});
       await plugin.hooks["after:package:createDeploymentArtifacts"]();
-      expect(functionWithTags).toHaveProperty("tags", { "env": "dev", "service": "dev" });
+      expect(functionWithTags).toHaveProperty("tags", { env: "dev", service: "dev" });
     });
 
     it("does not override existing tags", async () => {
@@ -283,7 +283,7 @@ describe("ServerlessPlugin", () => {
           "handler-2.js": "also-content",
         },
       });
-      const function_ = functionMock({ "service": "test" });
+      const function_ = functionMock({ service: "test" });
       const functionWithTags: FunctionDefinitionWithTags = function_;
       const serverless = {
         cli: { log: () => {} },
@@ -296,7 +296,7 @@ describe("ServerlessPlugin", () => {
       };
       const plugin = new ServerlessPlugin(serverless, {});
       await plugin.hooks["after:package:createDeploymentArtifacts"]();
-      expect(functionWithTags).toHaveProperty("tags", { "env": "dev", "service": "test" });
+      expect(functionWithTags).toHaveProperty("tags", { env: "dev", service: "test" });
     });
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -12,12 +12,25 @@ import { datadogDirectory } from "./wrapper";
 import fs from "fs";
 import mock from "mock-fs";
 import Aws from "serverless/plugins/aws/provider/awsProvider";
+import { FunctionDefinition } from "serverless";
+import { FunctionDefinitionWithTags } from "./index"
 
 function awsMock(): Aws {
   return {
     getStage: () => "dev",
     request: (service, method, params: any) => Promise.reject("Log group doesn't exist"),
   } as Aws;
+}
+
+function functionMock(mockTags: { [key: string]: string }): FunctionDefinition {
+  const mockPackage = { include: [], exclude: [] };
+  return {
+    name: "test",
+    package: mockPackage,
+    handler: "handler",
+    events: [],
+    tags: mockTags,
+  } as FunctionDefinition;
 }
 
 describe("ServerlessPlugin", () => {
@@ -163,7 +176,10 @@ describe("ServerlessPlugin", () => {
           "handler-2.js": "also-content",
         },
       });
-      const serverless = { cli: { log: () => {} }, service: { custom: {} } };
+      const serverless = { 
+        cli: { log: () => {} }, 
+        service: { custom: {}, getAllFunctions: () => [] } 
+      };
       const plugin = new ServerlessPlugin(serverless, {});
       await plugin.hooks["after:package:createDeploymentArtifacts"]();
       expect(fs.existsSync(datadogDirectory)).toBeFalsy();
@@ -181,6 +197,7 @@ describe("ServerlessPlugin", () => {
         getProvider: awsMock,
         service: {
           getServiceName: () => "dev",
+          getAllFunctions: () => [],
           provider: {
             compiledCloudFormationTemplate: {
               Resources: {
@@ -206,6 +223,80 @@ describe("ServerlessPlugin", () => {
       expect(serverless.service.provider.compiledCloudFormationTemplate.Resources).toHaveProperty(
         "FirstGroupSubscription",
       );
+    });
+
+    it("does not add or modify tags when enabledTags is false", async () => {
+      mock({
+        [datadogDirectory]: {
+          "handler-1.js": "my-content",
+          "handler-2.js": "also-content",
+        },
+      });
+      const function_ = functionMock({ "env": "test" });
+      const functionWithTags: FunctionDefinitionWithTags = function_;
+      const serverless = {
+        cli: { log: () => {} },
+        getProvider: awsMock,
+        service: {
+          getServiceName: () => "dev",
+          getAllFunctions: () => [function_],
+          getFunction: () => function_,
+          custom: {
+            datadog: {
+              enableTags: false,
+            },
+          },
+        },
+      };
+      const plugin = new ServerlessPlugin(serverless, {});
+      await plugin.hooks["after:package:createDeploymentArtifacts"]();
+      expect(functionWithTags).toHaveProperty("tags", { "env": "test" });
+    });
+
+    it("adds tags by default with service name and stage values", async () => {
+      mock({
+        [datadogDirectory]: {
+          "handler-1.js": "my-content",
+          "handler-2.js": "also-content",
+        },
+      });
+      const function_ = functionMock({});
+      const functionWithTags: FunctionDefinitionWithTags = function_;
+      const serverless = {
+        cli: { log: () => {} },
+        getProvider: awsMock,
+        service: {
+          getServiceName: () => "dev",
+          getAllFunctions: () => [function_],
+          getFunction: () => function_,
+        },
+      };
+      const plugin = new ServerlessPlugin(serverless, {});
+      await plugin.hooks["after:package:createDeploymentArtifacts"]();
+      expect(functionWithTags).toHaveProperty("tags", { "env": "dev", "service": "dev" });
+    });
+
+    it("does not override existing tags", async () => {
+      mock({
+        [datadogDirectory]: {
+          "handler-1.js": "my-content",
+          "handler-2.js": "also-content",
+        },
+      });
+      const function_ = functionMock({ "service": "test" });
+      const functionWithTags: FunctionDefinitionWithTags = function_;
+      const serverless = {
+        cli: { log: () => {} },
+        getProvider: awsMock,
+        service: {
+          getServiceName: () => "dev",
+          getAllFunctions: () => [function_],
+          getFunction: () => function_,
+        },
+      };
+      const plugin = new ServerlessPlugin(serverless, {});
+      await plugin.hooks["after:package:createDeploymentArtifacts"]();
+      expect(functionWithTags).toHaveProperty("tags", { "env": "dev", "service": "test" });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,10 @@ export interface FunctionDefinitionWithTags {
   tags?: { [key: string]: string };
 }
 
-const serviceKey = "service";
-const envKey = "env";
+enum TagKeys {
+  Service = "service",
+  Env = "env",
+}
 
 module.exports = class ServerlessPlugin {
   public hooks = {
@@ -120,7 +122,7 @@ module.exports = class ServerlessPlugin {
 
     if (config.enableTags) {
       this.serverless.cli.log("Adding service and environment tags to functions");
-      this.handleTags();
+      this.addServiceAndEnvTags();
     }
 
     this.serverless.cli.log("Cleaning up Datadog Handlers");
@@ -141,7 +143,7 @@ module.exports = class ServerlessPlugin {
     }
   }
 
-  private handleTags() {
+  private addServiceAndEnvTags() {
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionDefintion: FunctionDefinitionWithTags = this.serverless.service.getFunction(functionName);
 
@@ -150,13 +152,13 @@ module.exports = class ServerlessPlugin {
       }
 
       // Service tag
-      if (!functionDefintion.tags[serviceKey]) {
-        functionDefintion.tags[serviceKey] = this.serverless.service.getServiceName();
+      if (!functionDefintion.tags[TagKeys.Service]) {
+        functionDefintion.tags[TagKeys.Service] = this.serverless.service.getServiceName();
       }
 
       // Environment tag
-      if (!functionDefintion.tags[envKey]) {
-        functionDefintion.tags[envKey] = this.serverless.getProvider("aws").getStage();
+      if (!functionDefintion.tags[TagKeys.Env]) {
+        functionDefintion.tags[TagKeys.Env] = this.serverless.getProvider("aws").getStage();
       }
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,8 +118,6 @@ module.exports = class ServerlessPlugin {
     if (config.enableTags) {
       this.serverless.cli.log("Adding service and environment tags to functions");
       this.handleTags();
-    } else {
-      console.log('enableTags is false');
     }
 
     this.serverless.cli.log("Cleaning up Datadog Handlers");
@@ -157,8 +155,6 @@ module.exports = class ServerlessPlugin {
       if (!function_.tags['env']) {
         function_.tags['env'] = this.serverless.getProvider("aws").getStage();
       }
-
-      console.log(function_.tags);
     });
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,11 +142,11 @@ module.exports = class ServerlessPlugin {
   }
 
   private handleTags() {
-    this.serverless.service.getAllFunctions().forEach(functionName => {
+    this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionDefintion: FunctionDefinitionWithTags = this.serverless.service.getFunction(functionName);
 
       if (!functionDefintion.tags) {
-        functionDefintion.tags = {}
+        functionDefintion.tags = {};
       }
 
       // Service tag

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,18 +16,10 @@ import { cleanupHandlers, writeHandlers } from "./wrapper";
 import { hasWebpackPlugin } from "./util";
 import { TracingMode } from "./templates/common";
 import { addCloudWatchForwarderSubscriptions } from "./forwarder";
-import { Package, Event } from "serverless";
+import { FunctionDefinition } from "serverless";
 
 // Separate interface since DefinitelyTyped dependency currently doesn't include tags
-export interface FunctionDefinitionWithTags {
-  name: string;
-  package: Package;
-  runtime?: string;
-  handler: string;
-  timeout?: number;
-  memorySize?: number;
-  environment?: { [name: string]: string };
-  events: Event[];
+export interface FunctionDefinitionWithTags extends FunctionDefinition {
   tags?: { [key: string]: string };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { addCloudWatchForwarderSubscriptions } from "./forwarder";
 import { Package, Event } from "serverless";
 
 // Separate interface since DefinitelyTyped dependency currently doesn't include tags
-interface Function {
+export interface FunctionDefinitionWithTags {
   name: string;
   package: Package;
   runtime?: string;
@@ -140,7 +140,7 @@ module.exports = class ServerlessPlugin {
 
   private handleTags() {
     this.serverless.service.getAllFunctions().forEach(functionName => {
-      const function_: Function = this.serverless.service.getFunction(functionName);
+      const function_: FunctionDefinitionWithTags = this.serverless.service.getFunction(functionName);
 
       if (!function_.tags) {
           function_.tags = {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,11 @@ export interface FunctionDefinitionWithTags {
   memorySize?: number;
   environment?: { [name: string]: string };
   events: Event[];
-  tags?: { [key: string]: string }; 
+  tags?: { [key: string]: string };
 }
+
+const serviceKey = "service";
+const envKey = "env";
 
 module.exports = class ServerlessPlugin {
   public hooks = {
@@ -140,20 +143,20 @@ module.exports = class ServerlessPlugin {
 
   private handleTags() {
     this.serverless.service.getAllFunctions().forEach(functionName => {
-      const function_: FunctionDefinitionWithTags = this.serverless.service.getFunction(functionName);
+      const functionDefintion: FunctionDefinitionWithTags = this.serverless.service.getFunction(functionName);
 
-      if (!function_.tags) {
-          function_.tags = {}
+      if (!functionDefintion.tags) {
+        functionDefintion.tags = {}
       }
 
       // Service tag
-      if (!function_.tags['service']) {
-        function_.tags['service'] = this.serverless.service.getServiceName();
+      if (!functionDefintion.tags[serviceKey]) {
+        functionDefintion.tags[serviceKey] = this.serverless.service.getServiceName();
       }
 
       // Environment tag
-      if (!function_.tags['env']) {
-        function_.tags['env'] = this.serverless.getProvider("aws").getStage();
+      if (!functionDefintion.tags[envKey]) {
+        functionDefintion.tags[envKey] = this.serverless.getProvider("aws").getStage();
       }
     });
   }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

* By default, the plugin automatically tags the lambda functions with `service` and `env` using the service name and stage values.
* This will not override existing tags and can be turned off. 

### Motivation
To better organize serverless observability data using `service` and `env` tags.

### Testing Guidelines
Added some unit tests and tested on sandbox.
