### PR TITLE
Check provider level tags before auto tagging service & env

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ custom:
     # When set, the plugin will try to subscribe the lambda's cloudwatch log groups to the forwarder with the given arn.
     forwarder: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
 
-    # When set, the plugin will try to automatically tag lambdas with service and env, but will not override existing tags set under a specific function or the overall provider. Defaults to true.
+    # When set, the plugin will try to automatically tag lambdas with service and env, but will not override existing tags set on function or provider levels. Defaults to true.
     enableTags: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ custom:
     # When set, the plugin will try to subscribe the lambda's cloudwatch log groups to the forwarder with the given arn.
     forwarder: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
 
-    # When set, the plugin will try to automatically tag lambdas with service and env, but will not override existing tags. Defaults to true.
+    # When set, the plugin will try to automatically tag lambdas with service and env, but will not override existing tags set under a specific function or the overall provider. Defaults to true.
     enableTags: true
 ```
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -30,7 +30,7 @@ export interface Configuration {
   forwarder?: string;
 
   // When set, the plugin will try to automatically tag customers' lambda functions with service and env,
-  // but will not override existing tags. Defaults to true
+  // but will not override existing tags set under the function or the provider. Defaults to true
   enableTags: boolean;
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -30,7 +30,7 @@ export interface Configuration {
   forwarder?: string;
 
   // When set, the plugin will try to automatically tag customers' lambda functions with service and env,
-  // but will not override existing tags set under the function or the provider. Defaults to true
+  // but will not override existing tags set on function or provider levels. Defaults to true
   enableTags: boolean;
 }
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -286,19 +286,23 @@ describe("ServerlessPlugin", () => {
       expect(functionWithTags).toHaveProperty("tags", { env: "dev", service: "test" });
     });
 
-    it("does not override tags set under provider", async () => {
+    it("does not override tags set on provider level", async () => {
       const function_ = functionMock({});
       const functionWithTags: ExtendedFunctionDefinition = function_;
       const serverless = {
         cli: { log: () => {} },
         getProvider: awsMock,
         service: {
+          getServiceName: () => "my-service",
           getAllFunctions: () => [function_],
           getFunction: () => function_,
           provider: {
             region: "us-east-1",
             tags: {
               service: "service-name",
+            },
+            stackTags: {
+              env: "dev",
             },
           },
           functions: {
@@ -316,8 +320,8 @@ describe("ServerlessPlugin", () => {
       const plugin = new ServerlessPlugin(serverless, {});
       await plugin.hooks["after:package:createDeploymentArtifacts"]();
 
-      // The service tag will be set by serverless instead
-      expect(functionWithTags).toHaveProperty("tags", { env: "dev" });
+      // The service and env tags will be set with the values given in the provider instead
+      expect(functionWithTags).toHaveProperty("tags", {});
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,6 +118,11 @@ module.exports = class ServerlessPlugin {
     }
   }
 
+  /**
+   * Check for service and env tags on provider level (under tags and stackTags),
+   * as well as function level. Automatically create tags for service and env with
+   * properties from deployment configurations if needed; does not override any existing values.
+   */
   private addServiceAndEnvTags() {
     let providerServiceTagExists = false;
     let providerEnvTagExists = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,22 +119,29 @@ module.exports = class ServerlessPlugin {
   }
 
   private addServiceAndEnvTags() {
-    this.serverless.service.getAllFunctions().forEach((functionName) => {
-      const functionDefintion: ExtendedFunctionDefinition = this.serverless.service.getFunction(functionName);
+    let serviceName: string | undefined;
+    let env: string | undefined;
 
-      if (!functionDefintion.tags) {
-        functionDefintion.tags = {};
-      }
+    const provider = this.serverless.service.provider as any;
+    const customTags = provider.tags;
+    if (customTags !== undefined) {
+      serviceName = customTags[TagKeys.Service];
+      env = customTags[TagKeys.Env];
+    }
 
-      // Service tag
-      if (!functionDefintion.tags[TagKeys.Service]) {
-        functionDefintion.tags[TagKeys.Service] = this.serverless.service.getServiceName();
-      }
-
-      // Environment tag
-      if (!functionDefintion.tags[TagKeys.Env]) {
-        functionDefintion.tags[TagKeys.Env] = this.serverless.getProvider("aws").getStage();
-      }
-    });
+    if (serviceName === undefined || env === undefined) {
+      this.serverless.service.getAllFunctions().forEach((functionName) => {
+        const functionDefintion: ExtendedFunctionDefinition = this.serverless.service.getFunction(functionName);
+        if (!functionDefintion.tags) {
+          functionDefintion.tags = {};
+        }
+        if (!serviceName && !functionDefintion.tags[TagKeys.Service]) {
+          functionDefintion.tags[TagKeys.Service] = this.serverless.service.getServiceName();
+        }
+        if (!env && !functionDefintion.tags[TagKeys.Env]) {
+          functionDefintion.tags[TagKeys.Env] = this.serverless.getProvider("aws").getStage();
+        }
+      });
+    }
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,8 +132,8 @@ module.exports = class ServerlessPlugin {
 
     const providerStackTags = provider.stackTags;
     if (providerStackTags !== undefined) {
-      providerServiceTagExists = providerStackTags[TagKeys.Service] !== undefined;
-      providerEnvTagExists = providerStackTags[TagKeys.Env] !== undefined;
+      providerServiceTagExists = providerServiceTagExists || providerStackTags[TagKeys.Service] !== undefined;
+      providerEnvTagExists = providerEnvTagExists || providerStackTags[TagKeys.Env] !== undefined;
     }
 
     if (!providerServiceTagExists || !providerEnvTagExists) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Before automatically tagging `service` and `env` with the `service` and `stage` values from the serverless.yml file, check if these tags already exist on the provider level (either under `tags` or `stackTags`). If so, we do not override those values.

### Motivation
Current implementation only checks for existing tags on the function level, and will override values set on the provider level. 
https://github.com/DataDog/serverless-plugin-datadog/issues/52

### Testing Guidelines
Added unit tests and tested with sample lambda function on sandbox.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)
