### PR TITLE
Update layer versions

### DIFF
--- a/src/layers.json
+++ b/src/layers.json
@@ -2,155 +2,155 @@
   "regions": {
     "us-east-2": {
       "nodejs8.10": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38:19"
     },
     "us-east-1": {
       "nodejs8.10": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38:19"
     },
     "us-west-1": {
       "nodejs8.10": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38:19"
     },
     "us-west-2": {
       "nodejs8.10": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38:19"
     },
     "ap-east-1": {
-      "nodejs10.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38:19"
     },
     "ap-south-1": {
       "nodejs8.10": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38:19"
     },
     "ap-northeast-2": {
       "nodejs8.10": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38:19"
     },
     "ap-southeast-1": {
       "nodejs8.10": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38:19"
     },
     "ap-southeast-2": {
       "nodejs8.10": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38:19"
     },
     "ap-northeast-1": {
       "nodejs8.10": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38:19"
     },
     "ca-central-1": {
       "nodejs8.10": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38:19"
     },
     "eu-north-1": {
       "nodejs8.10": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38:19"
     },
     "eu-central-1": {
       "nodejs8.10": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38:19"
     },
     "eu-west-1": {
       "nodejs8.10": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38:19"
     },
     "eu-west-2": {
       "nodejs8.10": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38:19"
     },
     "eu-west-3": {
       "nodejs8.10": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38:19"
     },
     "sa-east-1": {
       "nodejs8.10": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:24",
-      "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:24",
-      "python2.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:18",
-      "python3.6": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:18",
-      "python3.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:18",
-      "python3.8": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:18"
+      "nodejs10.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:25",
+      "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:25",
+      "python2.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:19",
+      "python3.6": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:19",
+      "python3.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:19",
+      "python3.8": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:19"
     }
   }
 }


### PR DESCRIPTION
### Changes

Update layer versions for Node & Python. New versions of Node (25) and Python layer (19) published to prod which include the `function_version` tag in native traces.

### Motivation

https://datadoghq.atlassian.net/browse/SLS-588

### Testing Guidelines

Manually tested.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
