### PR TITLE
Set xray tracing default to `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ custom:
     # The log level, set to DEBUG for extended logging. Defaults to `info`.
     logLevel: "info"
 
-    # Enable X-Ray tracing on the Lambda functions and API Gateway integrations. Defaults to `true`.
-    enableXrayTracing: true
+    # Enable X-Ray tracing on the Lambda functions and API Gateway integrations. Defaults to `false`.
+    enableXrayTracing: false
 
     # Enable Datadog tracing on the Lambda function. Defaults to `true`.
     # When enabled, the parameter `forwarder` must be set.

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -29,7 +29,7 @@ describe("getConfig", () => {
       flushMetricsToLogs: true,
       logLevel: "debug",
       site: "datadoghq.com",
-      enableXrayTracing: true,
+      enableXrayTracing: false,
       enableDDTracing: true,
       enableTags: true,
     });

--- a/src/env.ts
+++ b/src/env.ts
@@ -45,7 +45,7 @@ export const defaultConfiguration: Configuration = {
   flushMetricsToLogs: true,
   logLevel: "info",
   site: "datadoghq.com",
-  enableXrayTracing: true,
+  enableXrayTracing: false,
   enableDDTracing: true,
   enableTags: true,
 };

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -158,7 +158,7 @@ describe("ServerlessPlugin", () => {
             tracing: {
               apiGateway: true,
               lambda: true,
-           },
+            },
           },
         },
       });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -69,10 +69,6 @@ describe("ServerlessPlugin", () => {
           },
           provider: {
             region: "us-east-1",
-            tracing: {
-              apiGateway: true,
-              lambda: true,
-            },
           },
         },
       });
@@ -116,16 +112,12 @@ describe("ServerlessPlugin", () => {
           },
           provider: {
             region: "us-east-1",
-            tracing: {
-              apiGateway: true,
-              lambda: true,
-            },
           },
         },
       });
     });
 
-    it("skips adding tracing when enableXrayTracing is false", async () => {
+    it("Adds tracing when enableXrayTracing is true", async () => {
       mock({});
       const serverless = {
         cli: {
@@ -144,7 +136,7 @@ describe("ServerlessPlugin", () => {
           },
           custom: {
             datadog: {
-              enableXrayTracing: false,
+              enableXrayTracing: true,
             },
           },
         },
@@ -152,7 +144,24 @@ describe("ServerlessPlugin", () => {
 
       const plugin = new ServerlessPlugin(serverless, {});
       await plugin.hooks["after:package:initialize"]();
-      expect(Object.keys(serverless.service.provider)).not.toContain("tracing");
+      expect(serverless).toMatchObject({
+        service: {
+          functions: {
+            node1: {
+              handler: "my-func.ev",
+              layers: [expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:.*/)],
+              runtime: "nodejs8.10",
+            },
+          },
+          provider: {
+            region: "us-east-1",
+            tracing: {
+              apiGateway: true,
+              lambda: true,
+           },
+          },
+        },
+      });
     });
   });
   describe("afterPackageFunction", () => {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Changes the default configuration of the plugin so Xray tracing is disabled i.e. `enableXrayTracing:false`.

**THIS IS POTENTIALLY A BREAKING CHANGE FOR CUSTOMERS THAT RELY ON DEFAULTS**


### Testing Guidelines
Modified unite tests to reflect new change.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
