### PR TITLE
Fix issue with script exiting early

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -54,9 +54,8 @@ yarn login
 echo "Updating layer versions"
 ./scripts/generate_layers_json.sh
 
-git diff --exit-code -s src/layers.json
-layers_updated=$?
-if [ $layers_updated -eq 1 ]; then
+files_changed=$(git status --porcelain)
+if [[ $files_changed == *"src/layers.json"* ]]; then
     echo "Layers updated, committing changes"
     git commit src/layers.json -m "Update layer versions"
 fi


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Currently script exits early because the following line exits with exit code 1:

```
git diff --exit-code -s src/layers.json
```

Modifying the logic to use `git status --porcelain ` which always returns with exit code 0.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
