### PR TITLE
Set env var `DD_TRACE_ENABLED` if specified in config

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -63,6 +63,7 @@ describe("setEnvConfiguration", () => {
           DD_KMS_API_KEY: "5678",
           DD_LOG_LEVEL: "debug",
           DD_SITE: "datadoghq.eu",
+          DD_TRACE_ENABLED: true,
         },
       },
     });
@@ -77,6 +78,7 @@ describe("setEnvConfiguration", () => {
           DD_KMS_API_KEY: "5678",
           DD_LOG_LEVEL: "debug",
           DD_SITE: "datadoghq.eu",
+          DD_TRACE_ENABLED: false,
         },
       },
     } as any;
@@ -102,6 +104,7 @@ describe("setEnvConfiguration", () => {
           DD_KMS_API_KEY: "5678",
           DD_LOG_LEVEL: "debug",
           DD_SITE: "datadoghq.eu",
+          DD_TRACE_ENABLED: false,
         },
       },
     });

--- a/src/env.ts
+++ b/src/env.ts
@@ -39,6 +39,7 @@ const apiKeyKMSEnvVar = "DD_KMS_API_KEY";
 const siteURLEnvVar = "DD_SITE";
 const logLevelEnvVar = "DD_LOG_LEVEL";
 const logForwardingEnvVar = "DD_FLUSH_TO_LOG";
+const ddTracingEnabledEnvVar = "DD_TRACE_ENABLED";
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
@@ -71,6 +72,9 @@ export function setEnvConfiguration(config: Configuration, service: Service) {
   }
   if (environment[logForwardingEnvVar] === undefined) {
     environment[logForwardingEnvVar] = config.flushMetricsToLogs;
+  }
+  if (config.enableDDTracing !== undefined && environment[ddTracingEnabledEnvVar] === undefined) {
+    environment[ddTracingEnabledEnvVar] = config.enableDDTracing;
   }
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

When `enableDDTracing:false` is passed in the custom datadog config for the plugin, the `DD_TRACE_ENABLED` env var is not set to false. This causes issues because in the js library we default to `true` if this env var is not set.  https://github.com/DataDog/datadog-lambda-js/blob/master/src/handler.ts#L6

This causes `enableDDTracing:false` to be ignored.

Potentially a breaking change on people relying on this bug's behaviour.

### Motivation

<!--- What inspired you to submit this pull request? --->
Investigating integration test flakiness brought me here

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [X] Bug fix
- [ ] New feature
- [X] Breaking change (potentially)
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [X] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
