### PR TITLE
fix: set correct default value for `flushMetricsToLogs` per docs

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -26,7 +26,7 @@ describe("getConfig", () => {
     expect(result).toEqual({
       addLayers: true,
       apiKey: "1234",
-      flushMetricsToLogs: true,
+      flushMetricsToLogs: false,
       logLevel: "debug",
       site: "datadoghq.com",
       enableXrayTracing: false,

--- a/src/env.ts
+++ b/src/env.ts
@@ -43,7 +43,7 @@ const ddTracingEnabledEnvVar = "DD_TRACE_ENABLED";
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
-  flushMetricsToLogs: true,
+  flushMetricsToLogs: false,
   logLevel: "info",
   site: "datadoghq.com",
   enableXrayTracing: false,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- set correct default value for `flushMetricsToLogs` per documentation

### Motivation

- when using the layer, the `flushMetricsToLogs` value was enabled while using the plugin despite the docs stating the default is disabled

<img width="759" alt="image" src="https://user-images.githubusercontent.com/10913471/91560151-5480ee00-e907-11ea-89bd-669d344a17b2.png">

### Testing Guidelines

CI tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
