### PR TITLE
:bug: #66: Use stackname to check the existent of subscription in forwarder

### DIFF
--- a/src/forwarder.spec.ts
+++ b/src/forwarder.spec.ts
@@ -198,7 +198,10 @@ describe("addCloudWatchForwarderSubscriptions", () => {
       "my-service",
     );
 
-    const aws = awsMock({ "/aws/lambda/first-group": [{ filterName: "myCustomStackName-FirstGroupSubscription-XXXX" }] }, "myCustomStackName");
+    const aws = awsMock(
+      { "/aws/lambda/first-group": [{ filterName: "myCustomStackName-FirstGroupSubscription-XXXX" }] },
+      "myCustomStackName",
+    );
 
     await addCloudWatchForwarderSubscriptions(service as Service, aws, "my-func");
     expect(service.provider.compiledCloudFormationTemplate.Resources).toMatchInlineSnapshot(`

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -41,7 +41,14 @@ export async function addCloudWatchForwarderSubscriptions(service: Service, aws:
 
     const logGroupName = resource.Properties.LogGroupName;
     const scopedSubName = `${name}Subscription`;
-    const expectedSubName = `${service.getServiceName()}-${aws.getStage()}-${scopedSubName}-`;
+
+    let expectedSubName = `${service.getServiceName()}-${aws.getStage()}-${scopedSubName}-`;
+
+    const stackName = aws.naming.getStackName();
+    if (stackName) {
+      expectedSubName = `${stackName}-${scopedSubName}-`;
+    }
+
     const canSub = await canSubscribeLogGroup(aws, logGroupName, expectedSubName);
     if (!canSub) {
       errors.push(`Subscription already exists for log group ${logGroupName}. Skipping subscribing Datadog forwarder.`);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -18,7 +18,7 @@ function awsMock(): Aws {
     getStage: () => "dev",
     request: (service, method, params: any) => Promise.reject("Log group doesn't exist"),
     naming: {
-      getStackName: () => '',
+      getStackName: () => "",
     } as { [key: string]: () => string },
   } as Aws;
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -17,6 +17,9 @@ function awsMock(): Aws {
   return {
     getStage: () => "dev",
     request: (service, method, params: any) => Promise.reject("Log group doesn't exist"),
+    naming: {
+      getStackName: () => '',
+    } as { [key: string]: () => string },
   } as Aws;
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Use the stackname (if defined) to check if a subscription can be added

### Motivation

The issue created by @bunnybilou: https://github.com/DataDog/serverless-plugin-datadog/issues/66

### Testing Guidelines

I add a unit test about in forwarder specs: "adds a subscription when an known subscription already exists and the stack name is defined"

### Additional Notes

To get the stack name I use the getStackName of the naming plugin

### Types of changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
