### PR TITLE
Add config for inject log context or patch the console in the layer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `enableDDTracing`    | Enable Datadog tracing on the Lambda function. Defaults to `true`. When enabled, it's required to set the `forwarder` parameter.                                                                                                                                                                                                                                                                         |
 | `forwarder`          | Setting this parameter subscribes the Lambda functions' CloudWatch log groups to the given Datadog forwarder Lambda function. Required when `enableDDTracing` is set to `true`.                                                                                                                                                                                                                 |
 | `enableTags`         | When set, automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition. It does NOT override if a `service` or `env` tag already exists. Defaults to `true`.                                                                                                                                      |
+| `injectLogContext`         | When set, the lambda layer will automatically patch console.log with Datadog's tracing ids. Defaults to `true`.                                                                                                                                      |
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 
@@ -49,8 +50,6 @@ custom:
     enableDDTracing: true
     forwarder: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
     enableTags: true
-
-    # When set, the lambda layer will automatically patch console.log with Datadog's tracing ids.
     injectLogContext: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ custom:
 
     # When set, automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition. It does NOT override if a `service` or `env` tag already exists. Defaults to `true`.
     enableTags: true
+
+    # When set, the lambda layer will automatically patch console.log with Datadog's tracing ids.
+    injectLogContext: true
 ```
 
 ## FAQ

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -32,6 +32,7 @@ describe("getConfig", () => {
       enableXrayTracing: false,
       enableDDTracing: true,
       enableTags: true,
+      injectLogContext: true,
     });
   });
 });
@@ -52,6 +53,7 @@ describe("setEnvConfiguration", () => {
         enableXrayTracing: true,
         enableDDTracing: true,
         enableTags: true,
+        injectLogContext: false,
       },
       service,
     );
@@ -64,6 +66,7 @@ describe("setEnvConfiguration", () => {
           DD_LOG_LEVEL: "debug",
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: true,
+          DD_LOGS_INJECTION: false,
         },
       },
     });
@@ -79,6 +82,7 @@ describe("setEnvConfiguration", () => {
           DD_LOG_LEVEL: "debug",
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
+          DD_LOGS_INJECTION: false,
         },
       },
     } as any;
@@ -93,6 +97,7 @@ describe("setEnvConfiguration", () => {
         enableXrayTracing: true,
         enableDDTracing: true,
         enableTags: true,
+        injectLogContext: true,
       },
       service,
     );
@@ -105,6 +110,7 @@ describe("setEnvConfiguration", () => {
           DD_LOG_LEVEL: "debug",
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
+          DD_LOGS_INJECTION: false,
         },
       },
     });

--- a/src/env.ts
+++ b/src/env.ts
@@ -32,6 +32,8 @@ export interface Configuration {
   // When set, the plugin will try to automatically tag customers' lambda functions with service and env,
   // but will not override existing tags set on function or provider levels. Defaults to true
   enableTags: boolean;
+  // When set, the lambda layer will automatically patch console.log with Datadog's tracing ids.
+  injectLogContext: boolean;
 }
 
 const apiKeyEnvVar = "DD_API_KEY";
@@ -40,6 +42,7 @@ const siteURLEnvVar = "DD_SITE";
 const logLevelEnvVar = "DD_LOG_LEVEL";
 const logForwardingEnvVar = "DD_FLUSH_TO_LOG";
 const ddTracingEnabledEnvVar = "DD_TRACE_ENABLED";
+const logInjectionEnvVar = "DD_LOGS_INJECTION";
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
@@ -49,6 +52,7 @@ export const defaultConfiguration: Configuration = {
   enableXrayTracing: false,
   enableDDTracing: true,
   enableTags: true,
+  injectLogContext: true,
 };
 
 export function setEnvConfiguration(config: Configuration, service: Service) {
@@ -75,6 +79,10 @@ export function setEnvConfiguration(config: Configuration, service: Service) {
   }
   if (config.enableDDTracing !== undefined && environment[ddTracingEnabledEnvVar] === undefined) {
     environment[ddTracingEnabledEnvVar] = config.enableDDTracing;
+  }
+
+  if (config.injectLogContext !== undefined && environment[logInjectionEnvVar] === undefined) {
+    environment[logInjectionEnvVar] = config.injectLogContext;
   }
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
This PR adds a config for users that are logging data and don't want the correlation info getting log as a prefix as it breaks some parsing downstream.

First step in https://github.com/DataDog/serverless-plugin-datadog/issues/59  -  Next will be actually injecting the correlation data into the objects/JSON strings.

### Motivation

<!--- What inspired you to submit this pull request? --->



### Testing Guidelines

<!--- How did you test this pull request? --->
Manually tested

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
