### PR TITLE
Instructions to exclude dd-trace when using webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,28 @@ If you use TypeScript, you may encounter the error of missing type definitions. 
 
 #### serverless-webpack
 
-If using `serverless-webpack`, make sure to also exclude `datadog-lambda-js` and `dd-trace` in your `serverless.yml` in addition to declaring them as external in your webpack config file:
-  ```
-  includeModules:
-    forceExclude:
-    - dd-trace
-    - datadog-lambda-js
-  ```
+If using `serverless-webpack`, make sure to also exclude `datadog-lambda-js` and `dd-trace` in your `serverless.yml` in addition to declaring them as external in your webpack config file.
+
+**webpack.config.js**
+```
+var nodeExternals = require('webpack-node-externals')
+
+module.exports = {
+  // we use webpack-node-externals to excludes all node deps.
+  // You can manually set the externals too.
+  externals: [nodeExternals(), 'dd-trace', 'datadog-lambda-js'],
+}
+```
+
+**serverless.yml**
+```
+custom:
+  webpack:
+    includeModules:
+      forceExclude:
+        - dd-trace
+        - datadog-lambda-js
+```
 
 
 ## Opening Issues

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you use TypeScript, you may encounter the error of missing type definitions. 
 
 #### serverless-webpack
 
-If using `serverless-webpack`, make sure to exclude `datadog-lambda-js` and `dd-trace` in your `serverless.yml`:
+If using `serverless-webpack`, make sure to also exclude `datadog-lambda-js` and `dd-trace` in your `serverless.yml` in addition to declaring them as external in your webpack config file:
   ```
   includeModules:
     forceExclude:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ plugins:
 
 If you use TypeScript, you may encounter the error of missing type definitions. A missing type definition happens when you use the prebuilt layers (for example, set `addLayers` to `true`, which is the default) and need to import helper functions from the `datadog-lambda-js` and `dd-trace` packages to submit custom metrics or instrument a specific function. To resolve the error, add `datadog-lambda-js` and `dd-trace` to the `devDependencies` list of your project's package.json.
 
+### Webpack
+
+`dd-trace` is known to be not compatible with webpack due to the use of conditional import and other issues. If using webpack, make sure to mark `datadog-lambda-js` and `dd-trace` as [externals](https://webpack.js.org/configuration/externals/) for webpack, so webpack knows these dependencies will be available in the runtime. You should also remove `datadog-lambda-js` and `dd-trace` from `package.json` and the build process to ensure you're using the versions provided by the Datadog Lambda Layer.
+
+#### serverless-webpack
+
+If using `serverless-webpack`, make sure to exclude `datadog-lambda-js` and `dd-trace` in your `serverless.yml`:
+  ```
+  includeModules:
+    forceExclude:
+    - dd-trace
+    - datadog-lambda-js
+  ```
+
+
 ## Opening Issues
 
 If you encounter a bug with this package, let us know by filing an issue! Before opening a new issue, please search the existing issues to avoid duplicates.


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add instructions on excluding `dd-trace` when using webpack as it's not webpack friendly. Also add instructions for users using `serverless-webpack`.

### Motivation

https://datadoghq.atlassian.net/browse/SLES-317

### Testing Guidelines

```
service: hello-dog

plugins:
  - serverless-plugin-datadog
  - serverless-webpack
provider:
  name: aws
  region: sa-east-1
  memorySize: 256

functions:
  harv-test-1:
    runtime: nodejs12.x
    handler: handler.handler
custom:
  webpack:
    includeModules:
      forceExclude:
        - dd-trace
```

```
const tracer = require("dd-trace");

async function getTransactions(event, ctx, cb) {
  tracer.trace("me-span", (span) => {
    const requestContextId = "BLANK";
    span.setTag("metag", requestContextId);
  });
  return {
    statusCode: 200,
  };
}

exports.handler = getTransactions;
```

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
