### PR TITLE
Force exclude dd-trace & datadog-lambda-js packages when using serverless-webpack

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -6,7 +6,7 @@
  * Copyright 2019 Datadog, Inc.
  */
 
-import { getConfig, defaultConfiguration, setEnvConfiguration } from "./env";
+import { getConfig, defaultConfiguration, setEnvConfiguration, forceExcludeDepsFromWebpack } from "./env";
 
 describe("getConfig", () => {
   it("get a default configuration when none is present", () => {
@@ -33,6 +33,79 @@ describe("getConfig", () => {
       enableDDTracing: true,
       enableTags: true,
       injectLogContext: true,
+    });
+  });
+});
+
+describe("forceExcludeDepsFromWebpack", () => {
+  it("adds missing fields to the webpack config", () => {
+    const service = {} as any;
+    forceExcludeDepsFromWebpack(service);
+    expect(service).toEqual({
+      custom: {
+        webpack: {
+          includeModules: {
+            forceExclude: ["datadog-lambda-js", "dd-trace"],
+          },
+        },
+      },
+    });
+  });
+  it("replaces includeModules:true", () => {
+    const service = {
+      custom: {
+        webpack: {
+          includeModules: true,
+        },
+      },
+    } as any;
+    forceExcludeDepsFromWebpack(service);
+    expect(service).toEqual({
+      custom: {
+        webpack: {
+          includeModules: {
+            forceExclude: ["datadog-lambda-js", "dd-trace"],
+          },
+        },
+      },
+    });
+  });
+  it("doesn't replace includeModules:false", () => {
+    const service = {
+      custom: {
+        webpack: {
+          includeModules: false,
+        },
+      },
+    } as any;
+    forceExcludeDepsFromWebpack(service);
+    expect(service).toEqual({
+      custom: {
+        webpack: {
+          includeModules: false,
+        },
+      },
+    });
+  });
+  it("doesn't modify webpack when dependencies already included", () => {
+    const service = {
+      custom: {
+        webpack: {
+          includeModules: {
+            forceExclude: ["datadog-lambda-js", "dd-trace"],
+          },
+        },
+      },
+    } as any;
+    forceExcludeDepsFromWebpack(service);
+    expect(service).toEqual({
+      custom: {
+        webpack: {
+          includeModules: {
+            forceExclude: ["datadog-lambda-js", "dd-trace"],
+          },
+        },
+      },
     });
   });
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -101,3 +101,44 @@ export function getConfig(service: Service): Configuration {
     ...datadog,
   };
 }
+
+export function forceExcludeDepsFromWebpack(service: Service) {
+  const includeModules = getPropertyFromPath(service, ["custom", "webpack", "includeModules"]);
+  if (includeModules === undefined) {
+    return;
+  }
+  let forceExclude = includeModules.forceExclude as string[] | undefined;
+  if (forceExclude === undefined) {
+    forceExclude = [];
+    includeModules.forceExclude = forceExclude;
+  }
+  if (!forceExclude.includes("datadog-lambda-js")) {
+    forceExclude.push("datadog-lambda-js");
+  }
+  if (!forceExclude.includes("dd-trace")) {
+    forceExclude.push("dd-trace");
+  }
+}
+
+function getPropertyFromPath(obj: any, path: string[]) {
+  for (const part of path) {
+    let prop = obj[part];
+    if (prop === undefined || prop === true) {
+      prop = {};
+      obj[part] = prop;
+    }
+    if (prop === false) {
+      return;
+    }
+    obj = prop;
+  }
+  return obj;
+}
+
+export function hasWebpackPlugin(service: Service) {
+  const plugins: string[] | undefined = (service as any).plugins;
+  if (plugins === undefined) {
+    return false;
+  }
+  return plugins.find((plugin) => plugin === "serverless-webpack") !== undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import * as Serverless from "serverless";
 import * as layers from "./layers.json";
 import { version } from "../package.json";
 
-import { getConfig, setEnvConfiguration } from "./env";
+import { getConfig, setEnvConfiguration, forceExcludeDepsFromWebpack, hasWebpackPlugin } from "./env";
 import { applyLayers, findHandlers, FunctionInfo, RuntimeType } from "./layer";
 import { TracingMode, enableTracing } from "./tracing";
 import { redirectHandlers } from "./wrapper";
@@ -72,6 +72,9 @@ module.exports = class ServerlessPlugin {
       this.serverless.cli.log("Adding Lambda Layers to functions");
       this.debugLogHandlers(handlers);
       applyLayers(this.serverless.service.provider.region, handlers, layers);
+      if (hasWebpackPlugin(this.serverless.service)) {
+        forceExcludeDepsFromWebpack(this.serverless.service);
+      }
     } else {
       this.serverless.cli.log("Skipping adding Lambda Layers, make sure you are packaging them yourself");
     }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Automatically force exclude `dd-trace` & `datadog-lambda-js` packages when using `serverless-webpack`.

### Motivation

https://datadoghq.atlassian.net/browse/SLS-772

### Testing Guidelines

```
service: hello-dog

plugins:
  - serverless-plugin-datadog
  - serverless-webpack
provider:
  name: aws
  region: sa-east-1
  memorySize: 256

functions:
  harv-test-1:
    runtime: nodejs12.x
    handler: handler.handler
custom:
  webpack:
    webpackConfig: "webpack.config.js"
```

should change to

```
service: hello-dog

plugins:
  - serverless-plugin-datadog
  - serverless-webpack
provider:
  name: aws
  region: sa-east-1
  memorySize: 256

functions:
  harv-test-1:
    runtime: nodejs12.x
    handler: handler.handler
custom:
  webpack:
    webpackConfig: "webpack.config.js"
    includeModules:
      forceExclude:
        - dd-trace
        - datadog-lambda-js
```

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
