### PR TITLE
Update layers with gov-cloud layers

### DIFF
--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -7,6 +7,10 @@
 
 # Writes layer info to easily readable json file
 
+# Call: ./scripts/generate_layers_json [-g]
+# Opts:
+#   -g: generate govcloud file
+
 set -e
 
 LAYER_NAMES=("Datadog-Node8-10" "Datadog-Node10-x" "Datadog-Node12-x" "Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -11,11 +11,17 @@ set -e
 
 LAYER_NAMES=("Datadog-Node8-10" "Datadog-Node10-x" "Datadog-Node12-x" "Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
 JSON_LAYER_NAMES=("nodejs8.10" "nodejs10.x" "nodejs12.x" "python2.7" "python3.6" "python3.7" "python3.8")
-AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
+AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
+
+FILE_NAME="src/layers.json"
 
 INPUT_JSON="{\"regions\":{}}"
 
-for region in "${AVAILABLE_REGIONS[@]}"
+if [ $1 = "-g" ]; then
+    FILE_NAME="src/layers-gov.json"
+fi
+
+for region in $AVAILABLE_REGIONS
 do
     for ((i=0;i<${#LAYER_NAMES[@]};++i));
     do
@@ -33,5 +39,5 @@ do
         fi
     done
 done
-echo "Writing to src/layers.json"
-jq '.' <<< $INPUT_JSON > src/layers.json
+echo "Writing to ${FILE_NAME}"
+jq '.' <<< $INPUT_JSON > $FILE_NAME

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 
 import * as Serverless from "serverless";
 import * as layers from "./layers.json";
+import * as govLayers from "./layers-gov.json";
 import { version } from "../package.json";
 
 import { getConfig, setEnvConfiguration, forceExcludeDepsFromWebpack, hasWebpackPlugin } from "./env";
@@ -71,7 +72,8 @@ module.exports = class ServerlessPlugin {
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Layers to functions");
       this.debugLogHandlers(handlers);
-      applyLayers(this.serverless.service.provider.region, handlers, layers);
+      const allLayers = { regions: { ...layers.regions, ...govLayers.regions } };
+      applyLayers(this.serverless.service.provider.region, handlers, allLayers);
       if (hasWebpackPlugin(this.serverless.service)) {
         forceExcludeDepsFromWebpack(this.serverless.service);
       }

--- a/src/layers-gov.json
+++ b/src/layers-gov.json
@@ -1,0 +1,20 @@
+{
+  "regions": {
+    "us-gov-west-1": {
+      "nodejs10.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python38:24"
+    },
+    "us-gov-east-1": {
+      "nodejs10.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python38:24"
+    }
+  }
+}

--- a/src/layers.json
+++ b/src/layers.json
@@ -1,156 +1,180 @@
 {
   "regions": {
-    "us-east-2": {
-      "nodejs8.10": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38:23"
-    },
-    "us-east-1": {
-      "nodejs8.10": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "us-west-1": {
-      "nodejs8.10": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "us-west-2": {
-      "nodejs8.10": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38:23"
-    },
-    "ap-east-1": {
-      "nodejs10.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "ap-south-1": {
-      "nodejs8.10": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "ap-northeast-2": {
-      "nodejs8.10": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38:23"
-    },
-    "ap-southeast-1": {
-      "nodejs8.10": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "ap-southeast-2": {
-      "nodejs8.10": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38:23"
-    },
-    "ap-northeast-1": {
-      "nodejs8.10": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "ca-central-1": {
-      "nodejs8.10": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38:23"
+    "af-south-1": {
+      "nodejs10.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python38:24"
     },
     "eu-north-1": {
       "nodejs8.10": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node8-10:18",
       "nodejs10.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node10-x:39",
       "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38:23"
+      "python2.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38:24"
     },
-    "eu-central-1": {
-      "nodejs8.10": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "eu-west-1": {
-      "nodejs8.10": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38:23"
-    },
-    "eu-west-2": {
-      "nodejs8.10": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node10-x:39",
-      "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38:23"
+    "ap-south-1": {
+      "nodejs8.10": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38:24"
     },
     "eu-west-3": {
       "nodejs8.10": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node8-10:18",
       "nodejs10.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node10-x:39",
       "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38:23"
+      "python2.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38:24"
+    },
+    "eu-west-2": {
+      "nodejs8.10": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38:24"
+    },
+    "eu-south-1": {
+      "nodejs10.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "eu-west-1": {
+      "nodejs8.10": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "ap-northeast-2": {
+      "nodejs8.10": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38:24"
+    },
+    "me-south-1": {
+      "nodejs10.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "ap-northeast-1": {
+      "nodejs8.10": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38:24"
     },
     "sa-east-1": {
       "nodejs8.10": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node8-10:18",
       "nodejs10.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:40",
       "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:39",
-      "python2.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:23",
-      "python3.6": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:23",
-      "python3.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:23",
-      "python3.8": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:23"
+      "python2.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "ca-central-1": {
+      "nodejs8.10": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "ap-east-1": {
+      "nodejs10.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "ap-southeast-1": {
+      "nodejs8.10": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "ap-southeast-2": {
+      "nodejs8.10": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38:24"
+    },
+    "eu-central-1": {
+      "nodejs8.10": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "us-east-1": {
+      "nodejs8.10": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "us-east-2": {
+      "nodejs8.10": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38:24"
+    },
+    "us-west-1": {
+      "nodejs8.10": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38:24"
+    },
+    "us-west-2": {
+      "nodejs8.10": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node8-10:18",
+      "nodejs10.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node10-x:39",
+      "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:39",
+      "python2.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python27:24",
+      "python3.6": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python36:24",
+      "python3.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python37:24",
+      "python3.8": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38:24"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Separates gov-cloud layers into another file, to prevent them from being overwritten by generate_layers_json.sh.
Also updates layer versions.

### Motivation

Gov cloud layers had been deleted from layers.json a few versions ago.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
