### PR TITLE
Add config to exclude function from Datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `forwarder`          | Setting this parameter subscribes the Lambda functions' CloudWatch log groups to the given Datadog forwarder Lambda function. Required when `enableDDTracing` is set to `true`.                                                                                                                                                                                                                 |
 | `enableTags`         | When set, automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition. It does NOT override if a `service` or `env` tag already exists. Defaults to `true`.                                                                                                                                      |
 | `injectLogContext`         | When set, the lambda layer will automatically patch console.log with Datadog's tracing ids. Defaults to `true`.                                                                                                                                      |
+| `exclude`         | When set, this plugin ignore all specified functions. Use this parameter if you have any functions that should not include Datadog functionality. Defaults to `[]`.                                                                                                                                      |
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 
@@ -50,7 +51,8 @@ custom:
     enableDDTracing: true
     forwarder: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
     enableTags: true
-    injectLogContext: true
+    injectLogContext: true,
+    exclude: ['dd-excluded-function'],
 ```
 
 **Note**: If you use webpack, Datadog recommends using the prebuilt layers by setting `addLayers` to `true`, which is the default, and add `datadog-lambda-js` and `dd-trace` to the [externals][6] section of your webpack config.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ custom:
     forwarder: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
     enableTags: true
     injectLogContext: true,
-    exclude: ['dd-excluded-function'],
+    exclude: ["dd-excluded-function"],
 ```
 
 **Note**: If you use webpack, Datadog recommends using the prebuilt layers by setting `addLayers` to `true`, which is the default, and add `datadog-lambda-js` and `dd-trace` to the [externals][6] section of your webpack config.

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -128,7 +128,7 @@ describe("setEnvConfiguration", () => {
         enableDDTracing: true,
         enableTags: true,
         injectLogContext: false,
-        exclude: ['dd-excluded-function']
+        exclude: ["dd-excluded-function"]
       },
       service,
     );
@@ -142,7 +142,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: true,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ['dd-excluded-function'],
+          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
         },
       },
     });
@@ -159,7 +159,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ['dd-excluded-function'],
+          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
         },
       },
     } as any;
@@ -189,7 +189,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ['dd-excluded-function'],
+          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
         },
       },
     });

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -33,6 +33,7 @@ describe("getConfig", () => {
       enableDDTracing: true,
       enableTags: true,
       injectLogContext: true,
+      exclude: [],
     });
   });
 });
@@ -127,6 +128,7 @@ describe("setEnvConfiguration", () => {
         enableDDTracing: true,
         enableTags: true,
         injectLogContext: false,
+        exclude: ['dd-excluded-function']
       },
       service,
     );
@@ -140,6 +142,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: true,
           DD_LOGS_INJECTION: false,
+          DD_EXCLUDED_FUNCTIONS: ['dd-excluded-function'],
         },
       },
     });
@@ -156,6 +159,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
+          DD_EXCLUDED_FUNCTIONS: ['dd-excluded-function'],
         },
       },
     } as any;
@@ -171,6 +175,7 @@ describe("setEnvConfiguration", () => {
         enableDDTracing: true,
         enableTags: true,
         injectLogContext: true,
+        exclude: [],
       },
       service,
     );
@@ -184,6 +189,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
+          DD_EXCLUDED_FUNCTIONS: ['dd-excluded-function'],
         },
       },
     });

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,6 +34,9 @@ export interface Configuration {
   enableTags: boolean;
   // When set, the lambda layer will automatically patch console.log with Datadog's tracing ids.
   injectLogContext: boolean;
+
+  // When set, this plugin will not try to redirect the handlers of these specified functions;
+  exclude: string[];
 }
 
 const apiKeyEnvVar = "DD_API_KEY";
@@ -43,6 +46,7 @@ const logLevelEnvVar = "DD_LOG_LEVEL";
 const logForwardingEnvVar = "DD_FLUSH_TO_LOG";
 const ddTracingEnabledEnvVar = "DD_TRACE_ENABLED";
 const logInjectionEnvVar = "DD_LOGS_INJECTION";
+const excludeEnvVar = "DD_EXCLUDED_FUNCTIONS";
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
@@ -53,6 +57,7 @@ export const defaultConfiguration: Configuration = {
   enableDDTracing: true,
   enableTags: true,
   injectLogContext: true,
+  exclude: [],
 };
 
 export function setEnvConfiguration(config: Configuration, service: Service) {
@@ -83,6 +88,10 @@ export function setEnvConfiguration(config: Configuration, service: Service) {
 
   if (config.injectLogContext !== undefined && environment[logInjectionEnvVar] === undefined) {
     environment[logInjectionEnvVar] = config.injectLogContext;
+  }
+
+  if (config.exclude !== undefined && environment[excludeEnvVar] === undefined) {
+    environment[excludeEnvVar] = config.exclude;
   }
 }
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -141,7 +141,7 @@ describe("ServerlessPlugin", () => {
           },
           custom: {
             datadog: {
-              exclude: ['node1'],
+              exclude: ["node1"],
               addLayers: true,
             },
           },

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -122,6 +122,50 @@ describe("ServerlessPlugin", () => {
       });
     });
 
+    it("ignores functions contained within exclude", async () => {
+      mock({});
+      const serverless = {
+        cli: {
+          log: () => {},
+        },
+        service: {
+          provider: {
+            region: "us-east-1",
+          },
+          functions: {
+            node1: {
+              handler: "my-func.ev",
+              layers: [],
+              runtime: "nodejs8.10",
+            },
+          },
+          custom: {
+            datadog: {
+              exclude: ['node1'],
+              addLayers: true,
+            },
+          },
+        },
+      };
+
+      const plugin = new ServerlessPlugin(serverless, {});
+      await plugin.hooks["after:package:initialize"]();
+      expect(serverless).toMatchObject({
+        service: {
+          functions: {
+            node1: {
+              handler: "my-func.ev",
+              layers: [],
+              runtime: "nodejs8.10",
+            },
+          },
+          provider: {
+            region: "us-east-1",
+          },
+        },
+      });
+    });
+
     it("Adds tracing when enableXrayTracing is true", async () => {
       mock({});
       const serverless = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ module.exports = class ServerlessPlugin {
     setEnvConfiguration(config, this.serverless.service);
 
     const defaultRuntime = this.serverless.service.provider.runtime;
-    const handlers = findHandlers(this.serverless.service, defaultRuntime);
+    const handlers = findHandlers(this.serverless.service, config.exclude, defaultRuntime);
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Layers to functions");
       this.debugLogHandlers(handlers);
@@ -110,7 +110,7 @@ module.exports = class ServerlessPlugin {
     }
 
     const defaultRuntime = this.serverless.service.provider.runtime;
-    const handlers = findHandlers(this.serverless.service, defaultRuntime);
+    const handlers = findHandlers(this.serverless.service, config.exclude, defaultRuntime);
     redirectHandlers(handlers, config.addLayers);
 
     addOutputLinks(this.serverless, config.site);

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -39,7 +39,7 @@ describe("findHandlers", () => {
       "func-h": { handler: "myfile.handler", runtime: "nodejs12.x" },
     });
 
-    const result = findHandlers(mockService);
+    const result = findHandlers(mockService, []);
     expect(result).toMatchObject([
       {
         handler: { handler: "myfile.handler", runtime: "nodejs8.10" },
@@ -87,7 +87,7 @@ describe("findHandlers", () => {
     const mockService = createMockService("us-east-1", {
       "func-a": { handler: "myfile.handler" },
     });
-    const result = findHandlers(mockService, "nodejs8.10");
+    const result = findHandlers(mockService, [], "nodejs8.10");
     expect(result).toMatchObject([
       {
         handler: {},

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -41,7 +41,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.8": RuntimeType.PYTHON,
 };
 
-export function findHandlers(service: Service, defaultRuntime?: string): FunctionInfo[] {
+export function findHandlers(service: Service, exclude: string[], defaultRuntime?: string): FunctionInfo[] {
   const funcs = (service as any).functions as { [key: string]: FunctionDefinition };
 
   return Object.entries(funcs)
@@ -55,7 +55,8 @@ export function findHandlers(service: Service, defaultRuntime?: string): Functio
       }
       return { type: RuntimeType.UNSUPPORTED, runtime, name, handler } as FunctionInfo;
     })
-    .filter((result) => result !== undefined) as FunctionInfo[];
+    .filter((result) => result !== undefined)
+    .filter((result) => exclude === undefined || (exclude !== undefined && !exclude.includes(result.name))) as FunctionInfo[];
 }
 
 export function applyLayers(region: string, handlers: FunctionInfo[], layers: LayerJSON) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR adds a config option that allows users to specify functions to be excluded from Datadog.

### Motivation

Currently, there is no way to prevent Datadog from updating certain functions. One example of a scenario where this is a problem is when using this plugin with `serverless-plugin-warmup`. Datadog will update the handler of the warmer function created by this plugin, which prevents it from working.

### Testing Guidelines

I added an additional test case and updated all associated test cases.

### Additional Notes

This issue is documented [here](https://github.com/FidelLimited/serverless-plugin-warmup/issues/231).

### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [X] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [X] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
