### PR TITLE
Revert "Add config to exclude function from Datadog"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ To further configure your plugin, use the following custom parameters in your `s
 | `forwarder`          | Setting this parameter subscribes the Lambda functions' CloudWatch log groups to the given Datadog forwarder Lambda function. Required when `enableDDTracing` is set to `true`.                                                                                                                                                                                                                 |
 | `enableTags`         | When set, automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition. It does NOT override if a `service` or `env` tag already exists. Defaults to `true`.                                                                                                                                      |
 | `injectLogContext`         | When set, the lambda layer will automatically patch console.log with Datadog's tracing ids. Defaults to `true`.                                                                                                                                      |
-| `exclude`         | When set, this plugin will ignore all specified functions. Use this parameter if you have any functions that should not include Datadog functionality. Defaults to `[]`.                                                                                                                                      |
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 
@@ -52,8 +51,6 @@ custom:
     forwarder: arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder
     enableTags: true
     injectLogContext: true
-    exclude: 
-      - dd-excluded-function
 ```
 
 **Note**: If you use webpack, Datadog recommends using the prebuilt layers by setting `addLayers` to `true`, which is the default, and add `datadog-lambda-js` and `dd-trace` to the [externals][6] section of your webpack config.

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -33,7 +33,6 @@ describe("getConfig", () => {
       enableDDTracing: true,
       enableTags: true,
       injectLogContext: true,
-      exclude: [],
     });
   });
 });
@@ -128,7 +127,6 @@ describe("setEnvConfiguration", () => {
         enableDDTracing: true,
         enableTags: true,
         injectLogContext: false,
-        exclude: ["dd-excluded-function"],
       },
       service,
     );
@@ -142,7 +140,6 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: true,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
         },
       },
     });
@@ -159,7 +156,6 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
         },
       },
     } as any;
@@ -175,7 +171,6 @@ describe("setEnvConfiguration", () => {
         enableDDTracing: true,
         enableTags: true,
         injectLogContext: true,
-        exclude: [],
       },
       service,
     );
@@ -189,7 +184,6 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
         },
       },
     });

--- a/src/env.ts
+++ b/src/env.ts
@@ -34,9 +34,6 @@ export interface Configuration {
   enableTags: boolean;
   // When set, the lambda layer will automatically patch console.log with Datadog's tracing ids.
   injectLogContext: boolean;
-
-  // When set, this plugin will not try to redirect the handlers of these specified functions;
-  exclude: string[];
 }
 
 const apiKeyEnvVar = "DD_API_KEY";
@@ -46,7 +43,6 @@ const logLevelEnvVar = "DD_LOG_LEVEL";
 const logForwardingEnvVar = "DD_FLUSH_TO_LOG";
 const ddTracingEnabledEnvVar = "DD_TRACE_ENABLED";
 const logInjectionEnvVar = "DD_LOGS_INJECTION";
-const excludeEnvVar = "DD_EXCLUDED_FUNCTIONS";
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
@@ -57,7 +53,6 @@ export const defaultConfiguration: Configuration = {
   enableDDTracing: true,
   enableTags: true,
   injectLogContext: true,
-  exclude: [],
 };
 
 export function setEnvConfiguration(config: Configuration, service: Service) {
@@ -88,10 +83,6 @@ export function setEnvConfiguration(config: Configuration, service: Service) {
 
   if (config.injectLogContext !== undefined && environment[logInjectionEnvVar] === undefined) {
     environment[logInjectionEnvVar] = config.injectLogContext;
-  }
-
-  if (config.exclude !== undefined && environment[excludeEnvVar] === undefined) {
-    environment[excludeEnvVar] = config.exclude;
   }
 }
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -122,50 +122,6 @@ describe("ServerlessPlugin", () => {
       });
     });
 
-    it("ignores functions contained within exclude", async () => {
-      mock({});
-      const serverless = {
-        cli: {
-          log: () => {},
-        },
-        service: {
-          provider: {
-            region: "us-east-1",
-          },
-          functions: {
-            node1: {
-              handler: "my-func.ev",
-              layers: [],
-              runtime: "nodejs8.10",
-            },
-          },
-          custom: {
-            datadog: {
-              exclude: ["node1"],
-              addLayers: true,
-            },
-          },
-        },
-      };
-
-      const plugin = new ServerlessPlugin(serverless, {});
-      await plugin.hooks["after:package:initialize"]();
-      expect(serverless).toMatchObject({
-        service: {
-          functions: {
-            node1: {
-              handler: "my-func.ev",
-              layers: [],
-              runtime: "nodejs8.10",
-            },
-          },
-          provider: {
-            region: "us-east-1",
-          },
-        },
-      });
-    });
-
     it("Adds tracing when enableXrayTracing is true", async () => {
       mock({});
       const serverless = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ module.exports = class ServerlessPlugin {
     setEnvConfiguration(config, this.serverless.service);
 
     const defaultRuntime = this.serverless.service.provider.runtime;
-    const handlers = findHandlers(this.serverless.service, config.exclude, defaultRuntime);
+    const handlers = findHandlers(this.serverless.service, defaultRuntime);
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Layers to functions");
       this.debugLogHandlers(handlers);
@@ -110,7 +110,7 @@ module.exports = class ServerlessPlugin {
     }
 
     const defaultRuntime = this.serverless.service.provider.runtime;
-    const handlers = findHandlers(this.serverless.service, config.exclude, defaultRuntime);
+    const handlers = findHandlers(this.serverless.service, defaultRuntime);
     redirectHandlers(handlers, config.addLayers);
 
     addOutputLinks(this.serverless, config.site);

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -39,7 +39,7 @@ describe("findHandlers", () => {
       "func-h": { handler: "myfile.handler", runtime: "nodejs12.x" },
     });
 
-    const result = findHandlers(mockService, []);
+    const result = findHandlers(mockService);
     expect(result).toMatchObject([
       {
         handler: { handler: "myfile.handler", runtime: "nodejs8.10" },
@@ -87,7 +87,7 @@ describe("findHandlers", () => {
     const mockService = createMockService("us-east-1", {
       "func-a": { handler: "myfile.handler" },
     });
-    const result = findHandlers(mockService, [], "nodejs8.10");
+    const result = findHandlers(mockService, "nodejs8.10");
     expect(result).toMatchObject([
       {
         handler: {},

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -41,7 +41,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.8": RuntimeType.PYTHON,
 };
 
-export function findHandlers(service: Service, exclude: string[], defaultRuntime?: string): FunctionInfo[] {
+export function findHandlers(service: Service, defaultRuntime?: string): FunctionInfo[] {
   const funcs = (service as any).functions as { [key: string]: FunctionDefinition };
 
   return Object.entries(funcs)
@@ -55,10 +55,7 @@ export function findHandlers(service: Service, exclude: string[], defaultRuntime
       }
       return { type: RuntimeType.UNSUPPORTED, runtime, name, handler } as FunctionInfo;
     })
-    .filter((result) => result !== undefined)
-    .filter(
-      (result) => exclude === undefined || (exclude !== undefined && !exclude.includes(result.name)),
-    ) as FunctionInfo[];
+    .filter((result) => result !== undefined) as FunctionInfo[];
 }
 
 export function applyLayers(region: string, handlers: FunctionInfo[], layers: LayerJSON) {


### PR DESCRIPTION
Reverts DataDog/serverless-plugin-datadog#87

Reverting because of this issue https://github.com/DataDog/serverless-plugin-datadog/pull/87#issuecomment-747177822. I believe [these lines](https://github.com/DataDog/serverless-plugin-datadog/pull/87/files#diff-00ee6a506727e42b3fb03361b8216c805ede24dc3985d237de852a73bda59f30R93-R95) are causing the issue, and they are unnecessary in the first place (i don't think we need to add its value as env var on the lambda function). However, a quick test without those lines also revealed that the intended exclusion behavior did not seem to work either. Given the urgency of the broken release, it's better to rollback this PR and investigate later.
