### PR TITLE
fix: store DD_EXLUDED_FUNCTIONS as comma-separated strings

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -128,7 +128,7 @@ describe("setEnvConfiguration", () => {
         enableDDTracing: true,
         enableTags: true,
         injectLogContext: false,
-        exclude: ["dd-excluded-function"],
+        exclude: ["dd-excluded-function", "dd-excluded-function-2"],
       },
       service,
     );
@@ -142,7 +142,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: true,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
+          DD_EXCLUDED_FUNCTIONS: "dd-excluded-function;dd-excluded-function-2",
         },
       },
     });
@@ -159,7 +159,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
+          DD_EXCLUDED_FUNCTIONS: "dd-excluded-function",
         },
       },
     } as any;
@@ -189,7 +189,7 @@ describe("setEnvConfiguration", () => {
           DD_SITE: "datadoghq.eu",
           DD_TRACE_ENABLED: false,
           DD_LOGS_INJECTION: false,
-          DD_EXCLUDED_FUNCTIONS: ["dd-excluded-function"],
+          DD_EXCLUDED_FUNCTIONS: "dd-excluded-function",
         },
       },
     });

--- a/src/env.ts
+++ b/src/env.ts
@@ -91,7 +91,7 @@ export function setEnvConfiguration(config: Configuration, service: Service) {
   }
 
   if (config.exclude !== undefined && environment[excludeEnvVar] === undefined) {
-    environment[excludeEnvVar] = config.exclude;
+    environment[excludeEnvVar] = config.exclude.join(";");
   }
 }
 


### PR DESCRIPTION
AWS Cloudformation does not allow for environment variables to be stored as lists. This commit
stores the DD_EXCLUDED_FUNCTIONS environment variable as a string separated with ";" instead
of a list.

Fixes #88 
