### PR TITLE
Add 'enabled' option in config to toggle dd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `forwarder`          | Setting this parameter subscribes the Lambda functions' CloudWatch log groups to the given Datadog forwarder Lambda function. Required when `enableDDTracing` is set to `true`.                                                                                                                                                                                                                 |
 | `enableTags`         | When set, automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition. It does NOT override if a `service` or `env` tag already exists. Defaults to `true`.                                                                                                                                      |
 | `injectLogContext`         | When set, the lambda layer will automatically patch console.log with Datadog's tracing ids. Defaults to `true`.                                                                                                                                      |
-| `enabled`            | When set to false, the DataDog plugin will stay inactive. Defaults to `true`. You can control this option using an environment variable, e.g. `enabled: ${strToBool(${env:DD_PLUGIN_ENABLED, true})}`, to activate/deactivate the plugin during deployment. |
+| `enabled`            | When set to false, the DataDog plugin will stay inactive. Defaults to `true`. You can control this option using an environment variable, e.g. `enabled: ${strToBool(${env:DD_PLUGIN_ENABLED, true})}`, to activate/deactivate the plugin during deployment. Alernatively, you can also use the value passed in through `--stage` to control this option, [see example.](#disable-plugin-for-particular-environment)|
 
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
@@ -108,6 +108,24 @@ If you run into the following error, double check the supplied Forwarder ARN is 
 An error occurred: GetaccountapiLogGroupSubscription - Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function. (Service: AWSLogs; Status Code: 400; Error Code: InvalidParameterException).
 ```
 
+### Disable Plugin for Particular Environment
+
+If you'd like to turn off the plugin based on the environment (passed via `--stage`), you can use something similar to the example below.
+
+```
+provider:
+  stage: ${self:opt.stage, 'dev'}
+
+custom:
+  staged: ${self:custom.stageVars.${self:provider.stage}, {}}
+
+  stageVars:
+    dev:
+      dd_enabled: false
+
+  datadog:
+    enabled: ${self:custom.staged.dd_enabled, true}
+```
 
 ## Opening Issues
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `forwarder`          | Setting this parameter subscribes the Lambda functions' CloudWatch log groups to the given Datadog forwarder Lambda function. Required when `enableDDTracing` is set to `true`.                                                                                                                                                                                                                 |
 | `enableTags`         | When set, automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition. It does NOT override if a `service` or `env` tag already exists. Defaults to `true`.                                                                                                                                      |
 | `injectLogContext`         | When set, the lambda layer will automatically patch console.log with Datadog's tracing ids. Defaults to `true`.                                                                                                                                      |
-| `enabled`            | When set to false, the DataDog plugin will stay inactive. Defaults to `true`. |
+| `enabled`            | When set to false, the DataDog plugin will stay inactive. Defaults to `true`. You can control this option using an environment variable, e.g. `enabled: ${strToBool(${env:DD_PLUGIN_ENABLED, true})}`, to activate/deactivate the plugin during deployment. |
 
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you use TypeScript, you may encounter the error of missing type definitions. 
 If using `serverless-webpack`, make sure to also exclude `datadog-lambda-js` and `dd-trace` in your `serverless.yml` in addition to declaring them as external in your webpack config file.
 
 **webpack.config.js**
-```
+```javascript
 var nodeExternals = require('webpack-node-externals')
 
 module.exports = {
@@ -89,7 +89,7 @@ module.exports = {
 ```
 
 **serverless.yml**
-```
+```yaml
 custom:
   webpack:
     includeModules:
@@ -112,7 +112,7 @@ An error occurred: GetaccountapiLogGroupSubscription - Could not execute the lam
 
 If you'd like to turn off the plugin based on the environment (passed via `--stage`), you can use something similar to the example below.
 
-```
+```yaml
 provider:
   stage: ${self:opt.stage, 'dev'}
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ To further configure your plugin, use the following custom parameters in your `s
 | `forwarder`          | Setting this parameter subscribes the Lambda functions' CloudWatch log groups to the given Datadog forwarder Lambda function. Required when `enableDDTracing` is set to `true`.                                                                                                                                                                                                                 |
 | `enableTags`         | When set, automatically tag the Lambda functions with the `service` and `env` tags using the `service` and `stage` values from the serverless application definition. It does NOT override if a `service` or `env` tag already exists. Defaults to `true`.                                                                                                                                      |
 | `injectLogContext`         | When set, the lambda layer will automatically patch console.log with Datadog's tracing ids. Defaults to `true`.                                                                                                                                      |
+| `enabled`            | When set to false, the DataDog plugin will stay inactive. Defaults to `true`. |
+
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,6 +9,8 @@
 import Service from "serverless/classes/Service";
 
 export interface Configuration {
+  // Whether Datadog is enabled. Defaults to true.
+  enabled?: boolean;
   // Whether to add the lambda layers, or expect the user's to bring their own
   addLayers: boolean;
   // Datadog API Key, only necessary when using metrics without log forwarding


### PR DESCRIPTION
This allows users to selectively enable datadog based
on stage or other serverless variables.

### Motivation

I don't want Datadog on my dev stage and I noticed #92 with
a similar issue.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

`yarn test` still passes?



### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog

Fixes #92.