### PR TITLE
Serverless plugin support for Enhanced Plugins Object

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -15,7 +15,7 @@ import {
 } from "./env";
 
 describe("hasWebpackPlugin", () => {
-  it("returns false when the serverless.yml plugin(s) object is not defined", () => {
+  it("returns false when the serverless.yml plugins object is not defined", () => {
     const service = {
       plugins: undefined,
     } as any;
@@ -23,7 +23,7 @@ describe("hasWebpackPlugin", () => {
     expect(result).toBe(false);
   });
 
-  it("returns false when the serverless.yml plugin(s) object does not define the serverless-webpack plugin", () => {
+  it("returns false when the serverless.yml plugins object does not define the serverless-webpack plugin", () => {
     const service = {
       plugins: ["serverless-plugin-datadog"],
     } as any;
@@ -31,7 +31,7 @@ describe("hasWebpackPlugin", () => {
     expect(result).toBe(false);
   });
 
-  it("returns true when the serverless.yml plugin(s) object does define the serverless-webpack plugin", () => {
+  it("returns true when the serverless.yml plugins object does define the serverless-webpack plugin", () => {
     const service = {
       plugins: ["serverless-plugin-datadog", "serverless-webpack"],
     } as any;
@@ -39,7 +39,7 @@ describe("hasWebpackPlugin", () => {
     expect(result).toBe(true);
   });
 
-  it("returns false when the serverless.yml enhanced plugin(s) object does not define the serverless-webpack plugin", () => {
+  it("returns false when the serverless.yml enhanced plugins object does not define the serverless-webpack plugin", () => {
     const service = {
       plugins: {
         localPath: "",
@@ -50,7 +50,7 @@ describe("hasWebpackPlugin", () => {
     expect(result).toBe(false);
   });
 
-  it("returns true when the serverless.yml enhanced plugin(s) object does define the serverless-webpack plugin", () => {
+  it("returns true when the serverless.yml enhanced plugins object does define the serverless-webpack plugin", () => {
     const service = {
       plugins: {
         localPath: "",

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -6,7 +6,61 @@
  * Copyright 2019 Datadog, Inc.
  */
 
-import { getConfig, defaultConfiguration, setEnvConfiguration, forceExcludeDepsFromWebpack } from "./env";
+import {
+  getConfig,
+  defaultConfiguration,
+  setEnvConfiguration,
+  forceExcludeDepsFromWebpack,
+  hasWebpackPlugin,
+} from "./env";
+
+describe("hasWebpackPlugin", () => {
+  it("returns false when the serverless.yml plugin(s) object is not defined", () => {
+    const service = {
+      plugins: undefined,
+    } as any;
+    const result = hasWebpackPlugin(service);
+    expect(result).toBe(false);
+  });
+
+  it("returns false when the serverless.yml plugin(s) object does not define the serverless-webpack plugin", () => {
+    const service = {
+      plugins: ["serverless-plugin-datadog"],
+    } as any;
+    const result = hasWebpackPlugin(service);
+    expect(result).toBe(false);
+  });
+
+  it("returns true when the serverless.yml plugin(s) object does define the serverless-webpack plugin", () => {
+    const service = {
+      plugins: ["serverless-plugin-datadog", "serverless-webpack"],
+    } as any;
+    const result = hasWebpackPlugin(service);
+    expect(result).toBe(true);
+  });
+
+  it("returns false when the serverless.yml enhanced plugin(s) object does not define the serverless-webpack plugin", () => {
+    const service = {
+      plugins: {
+        localPath: "",
+        modules: ["serverless-plugin-datadog"],
+      },
+    } as any;
+    const result = hasWebpackPlugin(service);
+    expect(result).toBe(false);
+  });
+
+  it("returns true when the serverless.yml enhanced plugin(s) object does define the serverless-webpack plugin", () => {
+    const service = {
+      plugins: {
+        localPath: "",
+        modules: ["serverless-plugin-datadog", "serverless-webpack"],
+      },
+    } as any;
+    const result = hasWebpackPlugin(service);
+    expect(result).toBe(true);
+  });
+});
 
 describe("getConfig", () => {
   it("get a default configuration when none is present", () => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -141,10 +141,25 @@ function getPropertyFromPath(obj: any, path: string[]) {
   return obj;
 }
 
+/*
+  ~check that plugins exists, if it does not then return false
+  ~decide if you have a normal array object or a enhanced object
+  ~if we have the normal array, check if webpack is in there
+  if we have an enhanced object, pull out modules and check if its in there
+*/
 export function hasWebpackPlugin(service: Service) {
   const plugins: string[] | undefined = (service as any).plugins;
   if (plugins === undefined) {
     return false;
   }
-  return plugins.find((plugin) => plugin === "serverless-webpack") !== undefined;
+  if (Array.isArray(plugins)) {
+    // We have a normal plugin array
+    return plugins.find((plugin) => plugin === "serverless-webpack") !== undefined;
+  }
+  // We have a enhanced plugins object
+  const modules: string[] | undefined = (service as any).plugins.modules;
+  if (modules === undefined) {
+    return false;
+  }
+  return modules.find((plugin) => plugin === "serverless-webpack") !== undefined;
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -40,7 +40,7 @@ export interface Configuration {
   // When set, this plugin will not try to redirect the handlers of these specified functions;
   exclude: string[];
 }
-
+const webpackPluginName = "serverless-webpack";
 const apiKeyEnvVar = "DD_API_KEY";
 const apiKeyKMSEnvVar = "DD_KMS_API_KEY";
 const siteURLEnvVar = "DD_SITE";
@@ -141,12 +141,6 @@ function getPropertyFromPath(obj: any, path: string[]) {
   return obj;
 }
 
-/*
-  ~check that plugins exists, if it does not then return false
-  ~decide if you have a normal array object or a enhanced object
-  ~if we have the normal array, check if webpack is in there
-  if we have an enhanced object, pull out modules and check if its in there
-*/
 export function hasWebpackPlugin(service: Service) {
   const plugins: string[] | undefined = (service as any).plugins;
   if (plugins === undefined) {
@@ -154,12 +148,12 @@ export function hasWebpackPlugin(service: Service) {
   }
   if (Array.isArray(plugins)) {
     // We have a normal plugin array
-    return plugins.find((plugin) => plugin === "serverless-webpack") !== undefined;
+    return plugins.find((plugin) => plugin === webpackPluginName) !== undefined;
   }
-  // We have a enhanced plugins object
+  // We have an enhanced plugins object
   const modules: string[] | undefined = (service as any).plugins.modules;
   if (modules === undefined) {
     return false;
   }
-  return modules.find((plugin) => plugin === "serverless-webpack") !== undefined;
+  return modules.find((plugin) => plugin === webpackPluginName) !== undefined;
 }


### PR DESCRIPTION
### Serverless plugin support for Enhanced Plugins Object
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR changes the logic of how we decide whether the serverless-webpack plugin is present in a Serverless config file by adding support for a [enhanced plugins object](https://www.serverless.com/framework/docs/providers/aws/guide/plugins/). This enables the customer to link local custom plugins in their Serverless deployments along with externally installed Serverless plugins such as serverless webpack or serverless-plugin-datadog.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Previously the Datadog serverless plugin only supported a normal plugin array object but when a customer would include an [enhanced plugin object](https://www.serverless.com/framework/docs/providers/aws/guide/plugins/) the deployment would fail due to the logic in the hasWebpackPlugin method.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
I added 5 unit tests for the hasWebpackPlugin method and manually tested through multiple deployments with different Serverless config settings.
<!--- How did you test this pull request? --->

### Additional Notes
On my machine the index.spec.ts unit test file is failing due to a unhandled promise rejection which should have nothing to do with the changes I added since it is occurring on both my master and development branch. I am also attempting to manually install the webpack plugin on a Serverless deployment as the final line of testing.
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
