### PR TITLE
Mock getAccountId in AWS Provider

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -17,6 +17,7 @@ const SEM_VER_REGEX = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\
 
 function awsMock(): Aws {
   return {
+    getAccountId: () => Promise.resolve("111111111111"),
     getStage: () => "dev",
     request: (service, method, params: any) => Promise.reject("Log group doesn't exist"),
     naming: {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Mocks the `getAccountId()` function in the AWS mock used in `index.spec.ts`. When this was not mocked, calls to this function would result in an unhandled promise rejection. This displayed a warning in Node 14 but breaks in Node 15 due to [changes in how unhandled rejections are handled](https://developer.ibm.com/languages/node-js/blogs/nodejs-15-release-blog/).

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
