### PR TITLE
Add node 14 support

### DIFF
--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node8-10" "Datadog-Node10-x" "Datadog-Node12-x" "Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
-JSON_LAYER_NAMES=("nodejs8.10" "nodejs10.x" "nodejs12.x" "python2.7" "python3.6" "python3.7" "python3.8")
+LAYER_NAMES=("Datadog-Node8-10" "Datadog-Node10-x" "Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
+JSON_LAYER_NAMES=("nodejs8.10" "nodejs10.x" "nodejs12.x" "nodejs14.x" "python2.7" "python3.6" "python3.7" "python3.8")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 FILE_NAME="src/layers.json"

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -39,6 +39,7 @@ describe("findHandlers", () => {
       "func-f": { handler: "myfile.handler", runtime: "python3.7" },
       "func-g": { handler: "myfile.handler", runtime: "python3.8" },
       "func-h": { handler: "myfile.handler", runtime: "nodejs12.x" },
+      "func-i": { handler: "myfile.handler", runtime: "nodejs14.x" },
     });
 
     const result = findHandlers(mockService, []);
@@ -82,6 +83,11 @@ describe("findHandlers", () => {
         handler: { runtime: "nodejs12.x" },
         type: RuntimeType.NODE,
         runtime: "nodejs12.x",
+      },
+      {
+        handler: { runtime: "nodejs14.x" },
+        type: RuntimeType.NODE,
+        runtime: "nodejs14.x",
       },
     ]);
   });

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -34,6 +34,7 @@ export interface LayerJSON {
 export const runtimeLookup: { [key: string]: RuntimeType } = {
   "nodejs10.x": RuntimeType.NODE,
   "nodejs12.x": RuntimeType.NODE,
+  "nodejs14.x": RuntimeType.NODE,
   "nodejs8.10": RuntimeType.NODE,
   "python2.7": RuntimeType.PYTHON,
   "python3.6": RuntimeType.PYTHON,

--- a/src/layers-gov.json
+++ b/src/layers-gov.json
@@ -1,20 +1,22 @@
 {
   "regions": {
     "us-gov-west-1": {
-      "nodejs10.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python38:28"
     },
     "us-gov-east-1": {
-      "nodejs10.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python38:28"
     }
   }
 }

--- a/src/layers.json
+++ b/src/layers.json
@@ -1,180 +1,200 @@
 {
   "regions": {
     "af-south-1": {
-      "nodejs10.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python38:28"
     },
     "eu-north-1": {
       "nodejs8.10": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38:28"
     },
     "ap-south-1": {
       "nodejs8.10": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38:28"
     },
     "eu-west-3": {
       "nodejs8.10": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38:28"
     },
     "eu-west-2": {
       "nodejs8.10": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38:28"
     },
     "eu-south-1": {
-      "nodejs10.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python38:28"
     },
     "eu-west-1": {
       "nodejs8.10": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38:28"
     },
     "ap-northeast-2": {
       "nodejs8.10": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38:28"
     },
     "me-south-1": {
-      "nodejs10.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python38:28"
     },
     "ap-northeast-1": {
       "nodejs8.10": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38:28"
     },
     "sa-east-1": {
       "nodejs8.10": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:45",
-      "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:28"
     },
     "ca-central-1": {
       "nodejs8.10": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38:28"
     },
     "ap-east-1": {
-      "nodejs10.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38:28"
     },
     "ap-southeast-1": {
       "nodejs8.10": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38:28"
     },
     "ap-southeast-2": {
       "nodejs8.10": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38:28"
     },
     "eu-central-1": {
       "nodejs8.10": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38:28"
     },
     "us-east-1": {
       "nodejs8.10": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38:28"
     },
     "us-east-2": {
       "nodejs8.10": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38:28"
     },
     "us-west-1": {
       "nodejs8.10": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38:28"
     },
     "us-west-2": {
       "nodejs8.10": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node8-10:18",
-      "nodejs10.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node10-x:44",
-      "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:44",
-      "python2.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python27:27",
-      "python3.6": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python36:27",
-      "python3.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python37:27",
-      "python3.8": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38:27"
+      "nodejs10.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node10-x:47",
+      "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:47",
+      "nodejs14.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node14-x:47",
+      "python2.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python27:28",
+      "python3.6": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python36:28",
+      "python3.7": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python37:28",
+      "python3.8": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38:28"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

Adds support for node v14 to the plugin.

### Motivation

New runtime for node.

### Testing Guidelines



### Additional Notes



### Types of changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
