### PR TITLE
Update snapshots during publish to prod

### DIFF
--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -197,7 +197,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590312126-2021-04-16T16:25:12.126Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python2.7",
@@ -207,7 +207,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -236,8 +236,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:33",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:6"
         ]
       },
       "DependsOn": [
@@ -251,7 +251,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590312126-2021-04-16T16:25:12.126Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.6",
@@ -261,7 +261,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -290,8 +290,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:33",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:6"
         ]
       },
       "DependsOn": [
@@ -305,7 +305,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590312126-2021-04-16T16:25:12.126Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.7",
@@ -315,7 +315,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -344,8 +344,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:33",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:6"
         ]
       },
       "DependsOn": [
@@ -359,7 +359,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590312126-2021-04-16T16:25:12.126Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.8",
@@ -369,7 +369,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -398,8 +398,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:33",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:6"
         ]
       },
       "DependsOn": [
@@ -413,7 +413,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590312126-2021-04-16T16:25:12.126Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs10.x",
@@ -423,7 +423,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -452,8 +452,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:49",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:52",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:6"
         ]
       },
       "DependsOn": [
@@ -467,7 +467,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590312126-2021-04-16T16:25:12.126Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs12.x",
@@ -477,7 +477,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -506,8 +506,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:49",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:52",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:6"
         ]
       },
       "DependsOn": [
@@ -521,7 +521,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590312126-2021-04-16T16:25:12.126Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs14.x",
@@ -531,7 +531,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -560,82 +560,82 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:49",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:52",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:6"
         ]
       },
       "DependsOn": [
         "JavascriptHello14DashxLogGroup"
       ]
     },
-    "PythonHello27LambdaVersion7nhM5ksd8FziMCh0Vwchlweb6oO5SDgajUZWCrAgmg": {
+    "PythonHello27LambdaVersionDC6k6sKDdOZW28roZDCB0Ci08XSzoocq8VUTMjvcIM": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello27LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "3Lf1FNAgobl6jXW0KPxZq0ooHhcIC//phaR8B39aG3c="
       }
     },
-    "PythonHello36LambdaVersionbEYH89EqgU88dmEXUrZIXmwVlTL9OQCZ2Y5FGy7ck": {
+    "PythonHello36LambdaVersionmxhKiYwAS3K27nncc5fJCmjyg8arHnyiRmnqbs7E": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello36LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "3Lf1FNAgobl6jXW0KPxZq0ooHhcIC//phaR8B39aG3c="
       }
     },
-    "PythonHello37LambdaVersionigS2REqKH5Si1NsSZv1tGTD5LfMiWqNklWeBjSb0RC8": {
+    "PythonHello37LambdaVersion9Oe1gjVf9qSovsvY8lecSGwJZbgKnHK7oSGlwz3ec": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello37LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "3Lf1FNAgobl6jXW0KPxZq0ooHhcIC//phaR8B39aG3c="
       }
     },
-    "PythonHello38LambdaVersionaOMSB09GwbKPeQKWJ3ArEIN44sdCcgDxusLXuhKQ": {
+    "PythonHello38LambdaVersionFu734MURFmqPX55hTSmGzDf0dOhUAUNb8U3Pu097io": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello38LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "3Lf1FNAgobl6jXW0KPxZq0ooHhcIC//phaR8B39aG3c="
       }
     },
-    "JavascriptHello10DashxLambdaVersion5B1MimbgvAkXapSzm8sco3tY7nGBbx96Br3eaW9ImA": {
+    "JavascriptHello10DashxLambdaVersion7BncHmWgg01iFXe07V6chgJvf99ItQdf2XRkXdVCrV4": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello10DashxLambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "3Lf1FNAgobl6jXW0KPxZq0ooHhcIC//phaR8B39aG3c="
       }
     },
-    "JavascriptHello12DashxLambdaVersionxx1Q5Oh5cAm1PJ8XX5L9SDNTkH9sWMJTyXk5Qjxopg": {
+    "JavascriptHello12DashxLambdaVersionFYBYVCnAcN4OEGScjWJhYn9Oc9KNPtPi8w4JWPVg4g": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello12DashxLambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "3Lf1FNAgobl6jXW0KPxZq0ooHhcIC//phaR8B39aG3c="
       }
     },
-    "JavascriptHello14DashxLambdaVersionoIY8GjqaZdCA8i8siPR4F4m40aFq6VkuR5wVLLzzuPo": {
+    "JavascriptHello14DashxLambdaVersionR9qBJ8bKU3HZtk743mG0oQXKJKH5BP6d5AD30zXS0S0": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello14DashxLambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "3Lf1FNAgobl6jXW0KPxZq0ooHhcIC//phaR8B39aG3c="
       }
     }
   },
@@ -648,43 +648,43 @@
     "PythonHello27LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello27LambdaVersion7nhM5ksd8FziMCh0Vwchlweb6oO5SDgajUZWCrAgmg"
+        "Ref": "PythonHello27LambdaVersionDC6k6sKDdOZW28roZDCB0Ci08XSzoocq8VUTMjvcIM"
       }
     },
     "PythonHello36LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello36LambdaVersionbEYH89EqgU88dmEXUrZIXmwVlTL9OQCZ2Y5FGy7ck"
+        "Ref": "PythonHello36LambdaVersionmxhKiYwAS3K27nncc5fJCmjyg8arHnyiRmnqbs7E"
       }
     },
     "PythonHello37LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello37LambdaVersionigS2REqKH5Si1NsSZv1tGTD5LfMiWqNklWeBjSb0RC8"
+        "Ref": "PythonHello37LambdaVersion9Oe1gjVf9qSovsvY8lecSGwJZbgKnHK7oSGlwz3ec"
       }
     },
     "PythonHello38LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello38LambdaVersionaOMSB09GwbKPeQKWJ3ArEIN44sdCcgDxusLXuhKQ"
+        "Ref": "PythonHello38LambdaVersionFu734MURFmqPX55hTSmGzDf0dOhUAUNb8U3Pu097io"
       }
     },
     "JavascriptHello10DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello10DashxLambdaVersion5B1MimbgvAkXapSzm8sco3tY7nGBbx96Br3eaW9ImA"
+        "Ref": "JavascriptHello10DashxLambdaVersion7BncHmWgg01iFXe07V6chgJvf99ItQdf2XRkXdVCrV4"
       }
     },
     "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionxx1Q5Oh5cAm1PJ8XX5L9SDNTkH9sWMJTyXk5Qjxopg"
+        "Ref": "JavascriptHello12DashxLambdaVersionFYBYVCnAcN4OEGScjWJhYn9Oc9KNPtPi8w4JWPVg4g"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello14DashxLambdaVersionoIY8GjqaZdCA8i8siPR4F4m40aFq6VkuR5wVLLzzuPo"
+        "Ref": "JavascriptHello14DashxLambdaVersionR9qBJ8bKU3HZtk743mG0oQXKJKH5BP6d5AD30zXS0S0"
       }
     }
   }

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -267,7 +267,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590309860-2021-04-16T16:25:09.860Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python2.7",
@@ -277,7 +277,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -306,7 +306,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:33"
         ]
       },
       "DependsOn": [
@@ -320,7 +320,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590309860-2021-04-16T16:25:09.860Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.6",
@@ -330,7 +330,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -359,7 +359,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:33"
         ]
       },
       "DependsOn": [
@@ -373,7 +373,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590309860-2021-04-16T16:25:09.860Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.7",
@@ -383,7 +383,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -412,7 +412,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:33"
         ]
       },
       "DependsOn": [
@@ -426,7 +426,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590309860-2021-04-16T16:25:09.860Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.8",
@@ -436,7 +436,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -465,7 +465,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:33"
         ]
       },
       "DependsOn": [
@@ -479,7 +479,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590309860-2021-04-16T16:25:09.860Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs10.x",
@@ -489,7 +489,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -518,7 +518,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:49"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:52"
         ]
       },
       "DependsOn": [
@@ -532,7 +532,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590309860-2021-04-16T16:25:09.860Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs12.x",
@@ -542,7 +542,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -571,7 +571,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:49"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:52"
         ]
       },
       "DependsOn": [
@@ -585,7 +585,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618590309860-2021-04-16T16:25:09.860Z/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs14.x",
@@ -595,7 +595,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "v2.20.0"
           },
           {
             "Key": "service",
@@ -624,81 +624,81 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:49"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:52"
         ]
       },
       "DependsOn": [
         "JavascriptHello14DashxLogGroup"
       ]
     },
-    "PythonHello27LambdaVersionMXswomMw2XKkq1pDsqxBAkvjDndJwIkA5G0coUb9Ko": {
+    "PythonHello27LambdaVersionYTeTALn0wOowcsEqPFnewlWr1VDy9ICedIdomQ8Y6Nk": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello27LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "EqXshXCwgufMk5fevg1Hr8U2oCT8FBnW1dtk5+zLDuE="
       }
     },
-    "PythonHello36LambdaVersionH6S1cDs1qwFrpDVU0RvOJEXKI0105b15eacbyB3sjkw": {
+    "PythonHello36LambdaVersiono7D4mxwWUHIrkH3ENnCg12qEPCIWHv7VcfsNEIFLM": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello36LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "EqXshXCwgufMk5fevg1Hr8U2oCT8FBnW1dtk5+zLDuE="
       }
     },
-    "PythonHello37LambdaVersionKYK2pF87346U2NLN2Skm8vMq7hyJDL7GnVRbYkOdPs": {
+    "PythonHello37LambdaVersionrMKMxq4TBN1Tl0lb7ElcXp0WIX98IunnQeaSnC5gA": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello37LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "EqXshXCwgufMk5fevg1Hr8U2oCT8FBnW1dtk5+zLDuE="
       }
     },
-    "PythonHello38LambdaVersionndzlLIq9hoee66zbVZlCCtIpOy6yOjzhKT5Z6vZr0jY": {
+    "PythonHello38LambdaVersiondzzHtxTSURjY9yTswqGRTrUxl9GhsAxiZyCl20ssQ4": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello38LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "EqXshXCwgufMk5fevg1Hr8U2oCT8FBnW1dtk5+zLDuE="
       }
     },
-    "JavascriptHello10DashxLambdaVersionEkfl9Tzjc54gsrJ3CLjMAAYEOvqrhzOeD5vcsq9gQ": {
+    "JavascriptHello10DashxLambdaVersionEtWTOgzECdBLd1Dbwet6lAArwp8wZZAFjFFVFTMc": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello10DashxLambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "EqXshXCwgufMk5fevg1Hr8U2oCT8FBnW1dtk5+zLDuE="
       }
     },
-    "JavascriptHello12DashxLambdaVersiontUzb40cZxleUUp9HIaTU7Ejdw3ZKlgkc9svk4EtCC0": {
+    "JavascriptHello12DashxLambdaVersionYe1Mxj6GuoYE779YmIseXVAx0FPpEuoBxJ2PCYzNN8I": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello12DashxLambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "EqXshXCwgufMk5fevg1Hr8U2oCT8FBnW1dtk5+zLDuE="
       }
     },
-    "JavascriptHello14DashxLambdaVersionpghqkm8wloyuyHLzchaLAVbICubHwJfppP3XRpx8": {
+    "JavascriptHello14DashxLambdaVersion1V9GKj2zRroIjTNgzKWkcWP2bV6d6PMkwv7z1C9JAac": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello14DashxLambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "EqXshXCwgufMk5fevg1Hr8U2oCT8FBnW1dtk5+zLDuE="
       }
     }
   },
@@ -711,43 +711,43 @@
     "PythonHello27LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello27LambdaVersionMXswomMw2XKkq1pDsqxBAkvjDndJwIkA5G0coUb9Ko"
+        "Ref": "PythonHello27LambdaVersionYTeTALn0wOowcsEqPFnewlWr1VDy9ICedIdomQ8Y6Nk"
       }
     },
     "PythonHello36LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello36LambdaVersionH6S1cDs1qwFrpDVU0RvOJEXKI0105b15eacbyB3sjkw"
+        "Ref": "PythonHello36LambdaVersiono7D4mxwWUHIrkH3ENnCg12qEPCIWHv7VcfsNEIFLM"
       }
     },
     "PythonHello37LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello37LambdaVersionKYK2pF87346U2NLN2Skm8vMq7hyJDL7GnVRbYkOdPs"
+        "Ref": "PythonHello37LambdaVersionrMKMxq4TBN1Tl0lb7ElcXp0WIX98IunnQeaSnC5gA"
       }
     },
     "PythonHello38LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello38LambdaVersionndzlLIq9hoee66zbVZlCCtIpOy6yOjzhKT5Z6vZr0jY"
+        "Ref": "PythonHello38LambdaVersiondzzHtxTSURjY9yTswqGRTrUxl9GhsAxiZyCl20ssQ4"
       }
     },
     "JavascriptHello10DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello10DashxLambdaVersionEkfl9Tzjc54gsrJ3CLjMAAYEOvqrhzOeD5vcsq9gQ"
+        "Ref": "JavascriptHello10DashxLambdaVersionEtWTOgzECdBLd1Dbwet6lAArwp8wZZAFjFFVFTMc"
       }
     },
     "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersiontUzb40cZxleUUp9HIaTU7Ejdw3ZKlgkc9svk4EtCC0"
+        "Ref": "JavascriptHello12DashxLambdaVersionYe1Mxj6GuoYE779YmIseXVAx0FPpEuoBxJ2PCYzNN8I"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello14DashxLambdaVersionpghqkm8wloyuyHLzchaLAVbICubHwJfppP3XRpx8"
+        "Ref": "JavascriptHello14DashxLambdaVersion1V9GKj2zRroIjTNgzKWkcWP2bV6d6PMkwv7z1C9JAac"
       }
     }
   }

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -17,6 +17,12 @@ else
     git pull origin master
 fi
 
+root_dir=$(pwd)
+if [[ "$root_dir" =~ .*"serverless-plugin-datadog/scripts".* ]]; then
+    echo "Make sure to run this script from the root `serverless-plugin-datadog` directory, aborting"
+    exit 1
+fi
+
 # Ensure no uncommitted changes
 if [ -n "$(git status --porcelain)" ]; then 
     echo "Detected uncommitted changes, aborting"
@@ -69,9 +75,12 @@ fi
 echo "Bumping the version number and committing the changes"
 yarn version --new-version "$VERSION"
 
-echo 'Publishing to Node'
 yarn test
 yarn build
+echo "Updating snapshots for integration tests"
+UPDATE_SNAPSHOTS=true ./scripts/run_integration_tests.sh
+
+echo 'Publishing to Node'
 yarn publish --new-version "$VERSION"
 
 echo 'Pushing updates to github'

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -62,15 +62,9 @@ done
 
 if [ "$UPDATE_SNAPSHOTS" = "true" ]; then
         cd $root_dir
-        BRANCH=$(git rev-parse --abbrev-ref HEAD)
-        if [ $BRANCH = "master" ]; then
-            echo "Error: Cannot update snapshot files directly through the master branch, please create a development branch then run the script again."
-            exit 1            
-        else
-            echo "Commiting and pushing up snapshot changes to ${BRANCH}. Please create a pull request on GitHub."
-            git add .
-            git commit -m "Update snapshots for integration tests"
-            git push origin $BRANCH
-        fi
+        echo "Staging and commiting snapshot changes"
+        git add .
+        git commit -m "Update snapshots for integration tests"
+        echo "Push up your commit!"
 fi
 exit 0


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
* This PR invokes `UPDATE_SNAPSHOTS=true ./scripts/run_integration_tests.sh` in the `publish_prod.sh` script to keep snapshots updated every-time there is a new release. 
* Added some minor edits to the `run_integration_tests.sh` script so that it can be called from the `publish_prod.sh` script and commit the changes correctly. 
* Added a check to make sure the `publish_prod.sh` script is called from the root directory in hopes of avoiding script failures when calling other scripts. If someone would run the script from the scripts directory like this `./publish_prod.sh` instead of from the root like this `./scripts/publish_prod.sh` then I believe [this](https://github.com/DataDog/serverless-plugin-datadog/blob/04b5ffc4d9670aa60a37e41b8f97526f32c10ffb/scripts/publish_prod.sh#L57) call would fail because it wouldn't be able to find the `scripts` directory if it was already in it.
* Finally I updated the snapshots which contained the new layer versions and SLS Plugin version
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Keep snapshots updated when a release is made. The last [v.2.20.0](https://github.com/DataDog/serverless-plugin-datadog/commit/04b5ffc4d9670aa60a37e41b8f97526f32c10ffb) commit failed the integration test workflow because the snapshots were not updated so I think updating the snapshots should be apart of the release process in hopes of keeping things automated and in sync.

### Additional Notes
Some of the changes in the CloudFormation template are random like the end of identifiers (I exclude those during our integration tests with a regex) but the important things are the updated layers and SLS plugin version.
<!--- What inspired you to submit this pull request? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
