### PR TITLE
Stabilize unstable CloudFormation template values using perl for Integration tests

### DIFF
--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -197,7 +197,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python2.7",
@@ -207,7 +207,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -236,8 +236,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -251,7 +251,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.6",
@@ -261,7 +261,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -290,8 +290,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -305,7 +305,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.7",
@@ -315,7 +315,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -344,8 +344,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -359,7 +359,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.8",
@@ -369,7 +369,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -398,8 +398,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:29",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -413,7 +413,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs10.x",
@@ -423,7 +423,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -452,8 +452,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:49",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -467,7 +467,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs12.x",
@@ -477,7 +477,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -506,8 +506,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:49",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -521,7 +521,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443590964-2021-04-14T23:39:50.964Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs14.x",
@@ -531,7 +531,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -560,82 +560,82 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:49",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:5"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
         "JavascriptHello14DashxLogGroup"
       ]
     },
-    "PythonHello27LambdaVersion7nhM5ksd8FziMCh0Vwchlweb6oO5SDgajUZWCrAgmg": {
+    "PythonHello27LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello27LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "XXXX"
       }
     },
-    "PythonHello36LambdaVersionbEYH89EqgU88dmEXUrZIXmwVlTL9OQCZ2Y5FGy7ck": {
+    "PythonHello36LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello36LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "XXXX"
       }
     },
-    "PythonHello37LambdaVersionigS2REqKH5Si1NsSZv1tGTD5LfMiWqNklWeBjSb0RC8": {
+    "PythonHello37LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello37LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "XXXX"
       }
     },
-    "PythonHello38LambdaVersionaOMSB09GwbKPeQKWJ3ArEIN44sdCcgDxusLXuhKQ": {
+    "PythonHello38LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello38LambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello10DashxLambdaVersion5B1MimbgvAkXapSzm8sco3tY7nGBbx96Br3eaW9ImA": {
+    "JavascriptHello10DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello10DashxLambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello12DashxLambdaVersionxx1Q5Oh5cAm1PJ8XX5L9SDNTkH9sWMJTyXk5Qjxopg": {
+    "JavascriptHello12DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello12DashxLambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello14DashxLambdaVersionoIY8GjqaZdCA8i8siPR4F4m40aFq6VkuR5wVLLzzuPo": {
+    "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello14DashxLambdaFunction"
         },
-        "CodeSha256": "laEHWZpINA4dtTbXWeyHR1xWuk/z13IqBhAUtNVbCqc="
+        "CodeSha256": "XXXX"
       }
     }
   },
@@ -648,43 +648,43 @@
     "PythonHello27LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello27LambdaVersion7nhM5ksd8FziMCh0Vwchlweb6oO5SDgajUZWCrAgmg"
+        "Ref": "PythonHello27LambdaVersionXXXX"
       }
     },
     "PythonHello36LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello36LambdaVersionbEYH89EqgU88dmEXUrZIXmwVlTL9OQCZ2Y5FGy7ck"
+        "Ref": "PythonHello36LambdaVersionXXXX"
       }
     },
     "PythonHello37LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello37LambdaVersionigS2REqKH5Si1NsSZv1tGTD5LfMiWqNklWeBjSb0RC8"
+        "Ref": "PythonHello37LambdaVersionXXXX"
       }
     },
     "PythonHello38LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello38LambdaVersionaOMSB09GwbKPeQKWJ3ArEIN44sdCcgDxusLXuhKQ"
+        "Ref": "PythonHello38LambdaVersionXXXX"
       }
     },
     "JavascriptHello10DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello10DashxLambdaVersion5B1MimbgvAkXapSzm8sco3tY7nGBbx96Br3eaW9ImA"
+        "Ref": "JavascriptHello10DashxLambdaVersionXXXX"
       }
     },
     "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionxx1Q5Oh5cAm1PJ8XX5L9SDNTkH9sWMJTyXk5Qjxopg"
+        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello14DashxLambdaVersionoIY8GjqaZdCA8i8siPR4F4m40aFq6VkuR5wVLLzzuPo"
+        "Ref": "JavascriptHello14DashxLambdaVersionXXXX"
       }
     }
   }

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -236,8 +236,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },
       "DependsOn": [
@@ -290,8 +290,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },
       "DependsOn": [
@@ -344,8 +344,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },
       "DependsOn": [
@@ -398,8 +398,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },
       "DependsOn": [
@@ -452,8 +452,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },
       "DependsOn": [
@@ -506,8 +506,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },
       "DependsOn": [
@@ -560,8 +560,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },
       "DependsOn": [

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -267,7 +267,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python2.7",
@@ -277,7 +277,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -306,7 +306,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -320,7 +320,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.6",
@@ -330,7 +330,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -359,7 +359,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -373,7 +373,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.7",
@@ -383,7 +383,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -412,7 +412,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -426,7 +426,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "datadog_lambda.handler.handler",
         "Runtime": "python3.8",
@@ -436,7 +436,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -465,7 +465,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:29"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -479,7 +479,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs10.x",
@@ -489,7 +489,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -518,7 +518,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:49"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -532,7 +532,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs12.x",
@@ -542,7 +542,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -571,7 +571,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:49"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
@@ -585,7 +585,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/1618443589221-2021-04-14T23:39:49.221Z/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
         },
         "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
         "Runtime": "nodejs14.x",
@@ -595,7 +595,7 @@
         "Tags": [
           {
             "Key": "dd_sls_plugin",
-            "Value": "v2.18.0"
+            "Value": "vX.XX.X"
           },
           {
             "Key": "service",
@@ -624,81 +624,81 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:49"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
         ]
       },
       "DependsOn": [
         "JavascriptHello14DashxLogGroup"
       ]
     },
-    "PythonHello27LambdaVersionMXswomMw2XKkq1pDsqxBAkvjDndJwIkA5G0coUb9Ko": {
+    "PythonHello27LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello27LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "XXXX"
       }
     },
-    "PythonHello36LambdaVersionH6S1cDs1qwFrpDVU0RvOJEXKI0105b15eacbyB3sjkw": {
+    "PythonHello36LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello36LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "XXXX"
       }
     },
-    "PythonHello37LambdaVersionKYK2pF87346U2NLN2Skm8vMq7hyJDL7GnVRbYkOdPs": {
+    "PythonHello37LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello37LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "XXXX"
       }
     },
-    "PythonHello38LambdaVersionndzlLIq9hoee66zbVZlCCtIpOy6yOjzhKT5Z6vZr0jY": {
+    "PythonHello38LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello38LambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello10DashxLambdaVersionEkfl9Tzjc54gsrJ3CLjMAAYEOvqrhzOeD5vcsq9gQ": {
+    "JavascriptHello10DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello10DashxLambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello12DashxLambdaVersiontUzb40cZxleUUp9HIaTU7Ejdw3ZKlgkc9svk4EtCC0": {
+    "JavascriptHello12DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello12DashxLambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello14DashxLambdaVersionpghqkm8wloyuyHLzchaLAVbICubHwJfppP3XRpx8": {
+    "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello14DashxLambdaFunction"
         },
-        "CodeSha256": "Ye26grxZSHQykIsq7fgp2gCJpvkAmNovWzG66l8lYTI="
+        "CodeSha256": "XXXX"
       }
     }
   },
@@ -711,43 +711,43 @@
     "PythonHello27LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello27LambdaVersionMXswomMw2XKkq1pDsqxBAkvjDndJwIkA5G0coUb9Ko"
+        "Ref": "PythonHello27LambdaVersionXXXX"
       }
     },
     "PythonHello36LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello36LambdaVersionH6S1cDs1qwFrpDVU0RvOJEXKI0105b15eacbyB3sjkw"
+        "Ref": "PythonHello36LambdaVersionXXXX"
       }
     },
     "PythonHello37LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello37LambdaVersionKYK2pF87346U2NLN2Skm8vMq7hyJDL7GnVRbYkOdPs"
+        "Ref": "PythonHello37LambdaVersionXXXX"
       }
     },
     "PythonHello38LambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "PythonHello38LambdaVersionndzlLIq9hoee66zbVZlCCtIpOy6yOjzhKT5Z6vZr0jY"
+        "Ref": "PythonHello38LambdaVersionXXXX"
       }
     },
     "JavascriptHello10DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello10DashxLambdaVersionEkfl9Tzjc54gsrJ3CLjMAAYEOvqrhzOeD5vcsq9gQ"
+        "Ref": "JavascriptHello10DashxLambdaVersionXXXX"
       }
     },
     "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersiontUzb40cZxleUUp9HIaTU7Ejdw3ZKlgkc9svk4EtCC0"
+        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello14DashxLambdaVersionpghqkm8wloyuyHLzchaLAVbICubHwJfppP3XRpx8"
+        "Ref": "JavascriptHello14DashxLambdaVersionXXXX"
       }
     }
   }

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -306,7 +306,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:XXX"
         ]
       },
       "DependsOn": [
@@ -359,7 +359,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:XXX"
         ]
       },
       "DependsOn": [
@@ -412,7 +412,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:XXX"
         ]
       },
       "DependsOn": [
@@ -465,7 +465,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:XXX"
         ]
       },
       "DependsOn": [
@@ -518,7 +518,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:XXX"
         ]
       },
       "DependsOn": [
@@ -571,7 +571,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX"
         ]
       },
       "DependsOn": [
@@ -624,7 +624,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Layer:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX"
         ]
       },
       "DependsOn": [

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -8,7 +8,8 @@
 
 set -e
 
-# To add new tests create a new yml file in the 'integration_tests' directory, append it to SERVERLESS_CONFIGS as well as creating a name for the snapshots that will be compared in your test.
+# To add new tests create a new yml file in the 'integration_tests' directory, append it to the SERVERLESS_CONFIGS array as well as creating a name for the 
+# snapshots that will be compared in your test. Add those snapshot names to the TEST_SNAPSHOTS and CORRECT_SNAPSHOTS arrays.
 # Note: Each yml config, test, and correct snapshot file should be at the same index in their own array. e.g. All the files for the forwarder test are at index 0.
 #       In order for this script to work correctly these arrays should have the same amount of elements.
 SERVERLESS_CONFIGS=("./serverless-forwarder.yml" "./serverless-extension.yml")

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-# To add new tests create a new yml file, append it to SERVERLESS_CONFIGS as well as creating a name for the snapshots that will be compared in your test.
+# To add new tests create a new yml file in the 'integration_tests' directory, append it to SERVERLESS_CONFIGS as well as creating a name for the snapshots that will be compared in your test.
 # Note: Each yml config, test, and correct snapshot file should be at the same index in their own array. e.g. All the files for the forwarder test are at index 0.
 #       In order for this script to work correctly these arrays should have the same amount of elements.
 SERVERLESS_CONFIGS=("./serverless-forwarder.yml" "./serverless-extension.yml")
@@ -68,8 +68,4 @@ for ((i = 0 ; i < ${#SERVERLESS_CONFIGS[@]} ; i++)); do
     fi
     echo "===================================="
 done
-
-if [ "$UPDATE_SNAPSHOTS" = "true" ]; then
-    echo "Commit the changes and create a PR"
-fi
 exit 0


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR uses Perl to stabilize unstable values in the CloudFormation template that would otherwise throw off the diff during snapshot integration testing.  This PR also updates the "correct" snapshots that are used to assert against.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Previously I used grep and a regex to exclude the patterns that were unstable but I didn't account for when a new release of the plugin or update of the layer ARNs.
Check out these commits:
* [v2.19.0](https://github.com/DataDog/serverless-plugin-datadog/runs/2356950462)
* [Update layers json](https://github.com/DataDog/serverless-plugin-datadog/runs/2357035317)
* [v2.20.0](https://github.com/DataDog/serverless-plugin-datadog/runs/2357050659)

Basically this PR ensures that updates like these ^ will not throw off the snapshots by stabilizing the values before performing the diff of the test and correct snapshot.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Manually tested the changes and asserted that the values I wanted to be substituted were in substituted by placeholder values.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
