### PR TITLE
Update layer versions by default in release script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Datadog, Inc.
+   Copyright 2021 Datadog, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Datadog datadog-lambda-layer-js
-Copyright 2019 Datadog, Inc.
+Copyright 2021 Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ For product feedback and questions, join the `#serverless` channel in the [Datad
 
 Unless explicitly stated otherwise, all files in this repository are licensed under the Apache License Version 2.0.
 
-This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2019 Datadog, Inc.
+This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
 [1]: https://docs.datadoghq.com/serverless/installation/python/?tab=serverlessframework
 [2]: https://docs.datadoghq.com/serverless/installation/nodejs/?tab=serverlessframework

--- a/scripts/check_layers_json.sh
+++ b/scripts/check_layers_json.sh
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2021 Datadog, Inc.
 
 set -e
 

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2021 Datadog, Inc.
 
 # Writes layer info to easily readable json file
 

--- a/scripts/generate_third_party_license_file.py
+++ b/scripts/generate_third_party_license_file.py
@@ -3,7 +3,7 @@
  under the Apache License Version 2.0.
 
  This product includes software developed at Datadog (https://www.datadoghq.com/).
- Copyright 2019 Datadog, Inc.
+ Copyright 2021 Datadog, Inc.
 '''
 
 import csv

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 import {

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 import Service from "serverless/classes/Service";

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 const ServerlessPlugin = require("./index");

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 import {

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 import { FunctionDefinition, FunctionDefinitionHandler } from "serverless";
 import Service from "serverless/classes/Service";

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 import Service from "serverless/classes/Service";

--- a/src/wrapper.spec.ts
+++ b/src/wrapper.spec.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 import { redirectHandlers } from "./wrapper";

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -3,7 +3,7 @@
  * under the Apache License Version 2.0.
  *
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2019 Datadog, Inc.
+ * Copyright 2021 Datadog, Inc.
  */
 
 import { FunctionDefinitionHandler } from "serverless";


### PR DESCRIPTION
### What does this PR do?

Previously, running the release script did not update the layer versions by default. To update the layer versions, one had to pass `UPDATE_LAYERS=true` when running the script.

This PR changes the default behavior to update the layer versions. To skip updating the layer versions, one can pass `UPDATE_LAYERS=false`. I added a confirmation message to confirm that updating the layer versions is desired.

The PR also includes the following minor changes:
- Add usage instructions to the release script
- A couple of minor formatting tweaks in the release script output
- Bonus: update copyright dates

### Motivation

Prevent us from accidentally releasing a new version without updating the layer versions, which is normally what we want to do.

### Testing Guidelines

Tested manually.

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
