### PR TITLE
feat: Fix floating promises in tests and index.js. Added tslint rule …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ package-lock.json
 test_forwarder_snapshot.json
 test_extension_snapshot.json
 test_extension_apigateway.json
+.node-version

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ module.exports = class ServerlessPlugin {
       }
     }
 
-    this.addPluginTag();
+    await this.addPluginTag();
 
     if (config.enableTags) {
       this.serverless.cli.log("Adding service and environment tags to functions");
@@ -144,7 +144,7 @@ module.exports = class ServerlessPlugin {
     const handlers = findHandlers(this.serverless.service, config.exclude, defaultRuntime);
     redirectHandlers(handlers, config.addLayers);
     if (config.integrationTesting === false) {
-      addOutputLinks(this.serverless, config.site);
+      await addOutputLinks(this.serverless, config.site);
     } else {
       this.serverless.cli.log("Skipped adding output links because 'integrationTesting' is set true");
     }

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -64,12 +64,6 @@ export async function deleteMonitor(monitorId: number, monitorsApiKey: string, m
   return response;
 }
 
-/**
- * TODO - refactor handleMonitorsApiResponse into this module
- * and use it here instead of throwing an error
- *
- * This is done because getExistingMonitors calls searchMonitors
- */
 export async function searchMonitors(queryTag: string, monitorsApiKey: string, monitorsAppKey: string) {
   const query = `tag:"${queryTag}"`;
   const response: Response = await fetch(`https://api.datadoghq.com/api/v1/monitor/search?query=${query}`, {

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -64,6 +64,12 @@ export async function deleteMonitor(monitorId: number, monitorsApiKey: string, m
   return response;
 }
 
+/**
+ * TODO - refactor handleMonitorsApiResponse into this module
+ * and use it here instead of throwing an error
+ *
+ * This is done because getExistingMonitors calls searchMonitors
+ */
 export async function searchMonitors(queryTag: string, monitorsApiKey: string, monitorsAppKey: string) {
   const query = `tag:"${queryTag}"`;
   const response: Response = await fetch(`https://api.datadoghq.com/api/v1/monitor/search?query=${query}`, {
@@ -76,7 +82,7 @@ export async function searchMonitors(queryTag: string, monitorsApiKey: string, m
   });
 
   if (response.status !== 200) {
-    console.error(new Error(`${response.status} ${response.statusText}`));
+    throw new Error(`Can't fetch monitors. Status code: ${response.status}. Message: ${response.statusText}`);
   }
 
   const json = await response.json();

--- a/src/monitors.ts
+++ b/src/monitors.ts
@@ -130,11 +130,10 @@ export function handleMonitorsApiResponse(response: Response, serverlessMonitorI
   if (response.status === 200) {
     return true;
   } else if (response.status === 400) {
-    console.log(`400 Bad Request: This could be due to incorrect syntax for ${serverlessMonitorId}`);
+    throw new Error(`400 Bad Request: This could be due to incorrect syntax for ${serverlessMonitorId}`);
   } else {
-    console.error(new Error(`${response.status} ${response.statusText}`));
+    throw new Error(`${response.status} ${response.statusText}`);
   }
-  return false;
 }
 
 /**

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "variable-name": {
       "options": ["allow-leading-underscore"]
     },
+    "no-floating-promises": true,
     "no-console": false,
     "no-empty": false,
     "trailing-comma": [


### PR DESCRIPTION
…to prevent floating promises. Throw errors from hanldeMonitorsApiResponse, as we cannot continue. Fix/update tests

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

closes #157 

### Motivation

Our business logic was to log an error, but not halt execution. Coupled with the fact that a number of our tests were missing `awaits`, our suite wasn't failing when it should have been.

This change:
1. Throws errors in `handleMonitorsApiResponse` instead of logging them, to halt execution (as we cannot continue)
2. Fixes missing `await`ing of promises in tests
3. Fixes (perhaps critical) missing `await` of promises in `index.ts`.
4. Adds a `tslint` rule `no-dangling-promises` to prevent this
5. Updates assertions to account for `handleMonitorsApiResponse` new behavior
6. Adds a comment to address a future refactor that I don't have time for ATM.

### Testing Guidelines

- [x] Automated testing
- [ ] Manual exercising of the `createMonitors` functionality. TODO!

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
