### PR TITLE
Normalize Python 3.9 layer version in integration tests

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -474,7 +474,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:45",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -458,7 +458,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:45",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -550,7 +550,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:45"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:XXX"
         ]
       },
       "DependsOn": [

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -47,7 +47,7 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
     # Normalize dd_sls_plugin version tag value
     perl -p -i -e 's/(v\d.\d\d.\d)/vX.XX.X/g' ${RAW_CFN_TEMPLATE}
     # Normalize Datadog Layer Arn versions
-    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-(Python27|Python36|Python37|Python38|Node10-x|Node12-x|Node14-x|Extension):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-\2:XXX/g' ${RAW_CFN_TEMPLATE}
+    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-(Python27|Python36|Python37|Python38|Python39|Node10-x|Node12-x|Node14-x|Extension):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-\2:XXX/g' ${RAW_CFN_TEMPLATE}
     # Normalize API Gateway timestamps
     perl -p -i -e 's/("ApiGatewayDeployment.*")/"ApiGatewayDeploymentxxxx"/g' ${RAW_CFN_TEMPLATE}
     cp ${RAW_CFN_TEMPLATE} ${TEST_SNAPSHOTS[i]}


### PR DESCRIPTION
### What does this PR do?

Normalize the version of the Python 3.9 layer in the integration tests.

### Motivation

This issue will cause integration tests to incorrectly fail every time the Python 3.9 layer version is updated.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
