### PR TITLE
[serverless][SLS-1460] update OOM monitor query to use just an enhanced metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ There are seven recommended monitors with default values pre-configured.
 | :------------------: | :--------------------------------------------------------------------------------------: | :--------: | :--------------------: |
 |   High Error Rate    |                       `aws.lambda.errors`/`aws.lambda.invocations`                       |   >= 10%   |   `high_error_rate`    |
 |       Timeout        |                      `aws.lambda.duration.max`/`aws.lambda.timeout`                      |    >= 1    |       `timeout`        |
-|    Out of Memory     |                           `aws.lambda.enhanced.out_of_memory`                            |     > 0    |    `out_of_memory`     |
+|    Out of Memory     |                           `aws.lambda.enhanced.out_of_memory`                            |    > 0     |    `out_of_memory`     |
 |  High Iterator Age   |                            `aws.lambda.iterator_age.maximum`                             | >= 24 hrs  |  `high_iterator_age`   |
 | High Cold Start Rate | `aws.lambda.enhanced.invocations(cold_start:true)`/<br>`aws.lambda.enhanced.invocations` |   >= 20%   | `high_cold_start_rate` |
 |    High Throttles    |                     `aws.lambda.throttles`/`aws.lambda.invocations`                      |   >= 20%   |    `high_throttles`    |

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ There are seven recommended monitors with default values pre-configured.
 | :------------------: | :--------------------------------------------------------------------------------------: | :--------: | :--------------------: |
 |   High Error Rate    |                       `aws.lambda.errors`/`aws.lambda.invocations`                       |   >= 10%   |   `high_error_rate`    |
 |       Timeout        |                      `aws.lambda.duration.max`/`aws.lambda.timeout`                      |    >= 1    |       `timeout`        |
-|    Out of Memory     |         `aws.lambda.lambda.enhanced.max_memory_used`/<br>`aws.lambda.memorysize`         |    >= 1    |    `out_of_memory`     |
+|    Out of Memory     |                           `aws.lambda.enhanced.out_of_memory`                            |     > 0    |    `out_of_memory`     |
 |  High Iterator Age   |                            `aws.lambda.iterator_age.maximum`                             | >= 24 hrs  |  `high_iterator_age`   |
 | High Cold Start Rate | `aws.lambda.enhanced.invocations(cold_start:true)`/<br>`aws.lambda.enhanced.invocations` |   >= 20%   | `high_cold_start_rate` |
 |    High Throttles    |                     `aws.lambda.throttles`/`aws.lambda.invocations`                      |   >= 20%   |    `high_throttles`    |

--- a/src/serverless_monitors.ts
+++ b/src/serverless_monitors.ts
@@ -28,9 +28,9 @@ export const TIMEOUT: ServerlessMonitor = {
 
 export const OUT_OF_MEMORY: ServerlessMonitor = {
   name: "Out of Memory on {{functionname.name}} in {{region.name}} for {{aws_account.name}}",
-  threshold: 1,
+  threshold: 0,
   query: (cloudFormationStackId: string, criticalThreshold: number) => {
-    return `avg(last_15m):sum:aws.lambda.enhanced.max_memory_used{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,functionname,region}.as_count() / sum:aws.lambda.memorysize{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,functionname,region}.as_count() >= ${criticalThreshold}`;
+    return `avg(last_15m):sum:aws.lambda.enhanced.out_of_memory{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,functionname,region} > ${criticalThreshold}`;
   },
   message:
     "At least one invocation in the selected time range ran out of memory. Resolution: Lambda functions that use more than their allotted amount of memory can be killed by the Lambda runtime. To users, this may look like failed requests to your application. [Distributed tracing](https://docs.datadoghq.com/serverless/distributed_tracing) can help you pinpoint parts of your application using excessive amounts of memory. Consider increasing the amount of memory your Lambda function is allowed to use.",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
[SLS-1460(https://datadoghq.atlassian.net/browse/SLS-1460) - updates the Out of Memory monitor to use the query `aws.lambda.enhanced.out_of_memory > 0` instead of an enhanced metric / delayed CW metric which would cause false positives.

### Motivation

<!--- What inspired you to submit this pull request? --->
Support request

### Testing Guidelines

<!--- How did you test this pull request? --->
tests pass + tested manually with a local build and deploy

Example [monitor](https://app.datadoghq.com/monitors/45771359) in the Serverless org.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
