### PR TITLE
bugfix: Remove dependency on serverless to fix no module error in certain cases

### DIFF
--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -1,6 +1,6 @@
 import { FunctionInfo } from "layer";
 import Service from "serverless/classes/Service";
-import { getLogGroupLogicalId } from "serverless/lib/plugins/aws/lib/naming";
+// import { getLogGroupLogicalId } from "serverless/lib/plugins/aws/lib/naming";
 import Aws = require("serverless/plugins/aws/provider/awsProvider");
 
 const logGroupKey = "AWS::Logs::LogGroup";
@@ -245,4 +245,17 @@ function subscribeToExecutionLogGroup(functionArn: string | CloudFormationObject
     },
   };
   return executionSubscription;
+}
+
+// Created from https://github.com/serverless/serverless/blob/master/lib/plugins/aws/lib/naming.js#L125-L127
+// Skipped lodash because Lambda Function Names can't include unicode chars or symbols
+function getLogGroupLogicalId(functionName: string): string {
+  if (!functionName) {
+    return "";
+  }
+  const uppercasedFirst = functionName[0].toUpperCase();
+  const rest = functionName.slice(1);
+  const upperCasedFunctionName = uppercasedFirst + rest;
+  const normalizedFunctionName = upperCasedFunctionName.replace(/-/g, "Dash").replace(/_/g, "Underscore");
+  return `${normalizedFunctionName}LogGroup`;
 }

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -1,6 +1,5 @@
 import { FunctionInfo } from "layer";
 import Service from "serverless/classes/Service";
-// import { getLogGroupLogicalId } from "serverless/lib/plugins/aws/lib/naming";
 import Aws = require("serverless/plugins/aws/provider/awsProvider");
 
 const logGroupKey = "AWS::Logs::LogGroup";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,6 @@
 
     "resolveJsonModule": true
   },
-  "include": ["src/**/*", "types/**/*.d.ts"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/types/serverless-naming.d.ts
+++ b/types/serverless-naming.d.ts
@@ -1,3 +1,0 @@
-declare module "serverless/lib/plugins/aws/lib/naming" {
-  export function getLogGroupLogicalId(functionName: string): string;
-}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Removes a dependency introduced in #145 which introduced a regression (#175).
In cases where users relied on a globally installed version of Serverless, and did not have a `NODE_PATH` which included globals, CJS would fail to resolve `getLogGroupLogicalName`, as global modules wouldn't be searched.

We don't really need the method from Serverless anyway, as it is quite simple

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
