### PR TITLE
fix 186: Properly concat layers from provider and function level.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ module.exports = class ServerlessPlugin {
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Library Layers to functions");
       this.debugLogHandlers(handlers);
-      applyLambdaLibraryLayers(this.serverless.service.provider.region, handlers, allLayers);
+      applyLambdaLibraryLayers(this.serverless.service, handlers, allLayers);
       if (hasWebpackPlugin(this.serverless.service)) {
         forceExcludeDepsFromWebpack(this.serverless.service);
       }
@@ -93,7 +93,7 @@ module.exports = class ServerlessPlugin {
     if (config.addExtension) {
       this.serverless.cli.log("Adding Datadog Lambda Extension Layer to functions");
       this.debugLogHandlers(handlers);
-      applyExtensionLayer(this.serverless.service.provider.region, handlers, allLayers);
+      applyExtensionLayer(this.serverless.service, handlers, allLayers);
     } else {
       this.serverless.cli.log("Skipping adding Lambda Extension Layer");
     }

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -16,7 +16,7 @@ import {
   pushLayerARN,
 } from "./layer";
 
-import { FunctionDefinition, FunctionDefinitionHandler, FunctionDefinitionImage } from "serverless";
+import { FunctionDefinitionHandler, FunctionDefinitionImage } from "serverless";
 import Service from "serverless/classes/Service";
 
 type FunctionDefinitionAll = FunctionDefinitionHandler | FunctionDefinitionImage;
@@ -25,9 +25,10 @@ function createMockService(
   region: string,
   funcs: { [funcName: string]: Partial<FunctionDefinitionAll> },
   plugins?: string[],
+  layers?: string[],
 ): Service {
   const service: Partial<Service> & { functions: any; plugins: any } = {
-    provider: { region } as any,
+    provider: { region, layers } as any,
     getAllFunctionsNames: () => Object.keys(funcs),
     getFunction: (name) => funcs[name] as FunctionDefinitionAll,
     functions: funcs as any,
@@ -120,7 +121,10 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:2" } },
     };
-    applyLambdaLibraryLayers("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
       layers: ["node:2"],
@@ -136,10 +140,37 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:2" } },
     };
-    applyLambdaLibraryLayers("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
       layers: ["node:1", "node:2"],
+    });
+  });
+
+  it("appends to the layer array if already present at provider level", () => {
+    const handler = {
+      handler: { runtime: "nodejs10.x", layers: ["node:1"] } as any,
+      type: RuntimeType.NODE,
+      runtime: "nodejs10.x",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: { "us-east-1": { "nodejs10.x": "node:2" } },
+    };
+    const mockService = createMockService(
+      "us-east-1",
+      {
+        "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+      },
+      [],
+      ["my-layer-1", "my-layer-2"],
+    );
+    applyLambdaLibraryLayers(mockService, [handler], layers);
+    expect(handler.handler).toEqual({
+      runtime: "nodejs10.x",
+      layers: ["my-layer-1", "my-layer-2", "node:1", "node:2"],
     });
   });
 
@@ -152,7 +183,10 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:1" } },
     };
-    applyLambdaLibraryLayers("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
       layers: ["node:1"],
@@ -168,7 +202,10 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:1" } },
     };
-    applyLambdaLibraryLayers("us-east-2", [handler], layers);
+    const mockService = createMockService("us-east-2", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
     });
@@ -183,7 +220,10 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "python2.7": "python:2" } },
     };
-    applyLambdaLibraryLayers("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
     });
@@ -198,7 +238,10 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "python2.7": "python:2" } },
     };
-    applyLambdaLibraryLayers("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({});
   });
 
@@ -210,7 +253,10 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "python2.7": "python:2" } },
     };
-    applyLambdaLibraryLayers("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({});
   });
 
@@ -227,7 +273,10 @@ describe("applyLambdaLibraryLayers", () => {
         },
       },
     };
-    applyLambdaLibraryLayers("us-gov-east-1", [handler], layers);
+    const mockService = createMockService("us-gov-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
       layers: ["arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node10-x:30"],
@@ -243,7 +292,10 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { extension: "extension:5" } },
     };
-    applyExtensionLayer("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyExtensionLayer(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
       layers: ["extension:5"],
@@ -259,8 +311,11 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:2", extension: "extension:5" } },
     };
-    applyLambdaLibraryLayers("us-east-1", [handler], layers);
-    applyExtensionLayer("us-east-1", [handler], layers);
+    const mockService = createMockService("us-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+    });
+    applyLambdaLibraryLayers(mockService, [handler], layers);
+    applyExtensionLayer(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
       layers: ["node:2", "extension:5"],


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Closes #186

### Motivation
Layers at the provider level were being ignored, and therefore effectively dropped by the plugin.

### Testing Guidelines

Automated and manual testing:
![image](https://user-images.githubusercontent.com/1598537/138137779-67006b7f-f721-4208-929c-8e43c94f52e9.png)
Verified custom layer and extension layer are present (note I'm intentionally not adding dd-lambda-js layer):
![image](https://user-images.githubusercontent.com/1598537/138137541-b41d6851-d0e2-4392-aeba-3328c95b502d.png)

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
