### PR TITLE
Fail on mon creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ import { addOutputLinks, printOutputs } from "./output";
 import { FunctionDefinition } from "serverless";
 import { setMonitors } from "./monitors";
 import { getCloudFormationStackId } from "./monitor-api-requests";
-import { stringify } from "querystring";
 
 // Separate interface since DefinitelyTyped currently doesn't include tags or env
 export interface ExtendedFunctionDefinition extends FunctionDefinition {

--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,7 @@ module.exports = class ServerlessPlugin {
         }
       } catch (err) {
         this.serverless.cli.log("Error occurred when configuring monitors.");
+        throw err;
       }
     }
     return printOutputs(this.serverless, config.site);


### PR DESCRIPTION
### What does this PR do?

Raise an exception when failing to update monitors

### Motivation

Failing to create monitors is difficult to detect and diagnose at the moment. This makes it awkward to use in a pipeline and hard to troubleshoot.

### Testing Guidelines

Have an invalid monitoring configuration, run `sls deploy --stage foo`, validate that:

* exit status is non zero
* error contains status code

### Types of changes

Bug fix

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
