### PR TITLE
fix: Honor framework functionality - do not merge service and function level layers.

### DIFF
--- a/integration_tests/FunctionLevelLayer/file.txt
+++ b/integration_tests/FunctionLevelLayer/file.txt
@@ -1,0 +1,1 @@
+Also Aaron Stuyvenberg

--- a/integration_tests/ProviderLevelLayer/file.txt
+++ b/integration_tests/ProviderLevelLayer/file.txt
@@ -1,0 +1,1 @@
+Aaron Stuyvenberg

--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -1056,7 +1056,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/custom-resources.zip"
         },
         "FunctionName": "dd-sls-plugin-integration-test-dev-custom-resource-apigw-cw-role",
         "Handler": "apiGatewayCloudWatchRole/handler.handler",

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -202,6 +202,35 @@
         }
       }
     },
+    "ProviderLevelLayerLambdaLayer": {
+      "Type": "AWS::Lambda::LayerVersion",
+      "Properties": {
+        "Content": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "LayerName": "dd-sls-plugin-integration-test-dev-ProviderLevelLayer",
+        "Description": "It's a text file",
+        "CompatibleRuntimes": [
+          "nodejs12.x"
+        ]
+      }
+    },
+    "FunctionLevelLayerLambdaLayer": {
+      "Type": "AWS::Lambda::LayerVersion",
+      "Properties": {
+        "Content": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "LayerName": "dd-sls-plugin-integration-test-dev-FunctionLevelLayer",
+        "Description": "It's also a text file"
+      }
+    },
     "PythonHello27LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -249,6 +278,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python27:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -304,6 +336,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python36:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -359,6 +394,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -414,6 +452,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -469,6 +510,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -524,6 +568,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node10-x:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -579,6 +626,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "FunctionLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -634,6 +684,9 @@
           ]
         },
         "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
@@ -661,7 +714,12 @@
             "IamRoleLambdaExecution",
             "Arn"
           ]
-        }
+        },
+        "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          }
+        ]
       },
       "DependsOn": [
         "ExcludeThisLogGroup"
@@ -727,16 +785,6 @@
         "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello12DashxLambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "JavascriptHello12DashxLambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
     "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -756,6 +804,16 @@
         },
         "CodeSha256": "XXXX"
       }
+    },
+    "JavascriptHello12DashxLambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "JavascriptHello12DashxLambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
     }
   },
   "Outputs": {
@@ -765,6 +823,52 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-ServerlessDeploymentBucketName"
+      }
+    },
+    "ProviderLevelLayerLambdaLayerQualifiedArn": {
+      "Description": "Current Lambda layer version",
+      "Value": {
+        "Ref": "ProviderLevelLayerLambdaLayer"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerQualifiedArn"
+      }
+    },
+    "ProviderLevelLayerLambdaLayerHash": {
+      "Description": "Current Lambda layer hash",
+      "Value": "ca99f65eb22bc573edd4f9ac2a087d0dd5acc751",
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerHash"
+      }
+    },
+    "ProviderLevelLayerLambdaLayerS3Key": {
+      "Description": "Current Lambda layer S3Key",
+      "Value": "serverless/dd-sls-plugin-integration-test/dev/1635525038103-2021-10-29T16:30:38.103Z/ProviderLevelLayer.zip",
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerS3Key"
+      }
+    },
+    "FunctionLevelLayerLambdaLayerQualifiedArn": {
+      "Description": "Current Lambda layer version",
+      "Value": {
+        "Ref": "FunctionLevelLayerLambdaLayer"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-FunctionLevelLayerLambdaLayerQualifiedArn"
+      }
+    },
+    "FunctionLevelLayerLambdaLayerHash": {
+      "Description": "Current Lambda layer hash",
+      "Value": "0f01889b95d76f2e1385d132d4a12c58ca99d568",
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-FunctionLevelLayerLambdaLayerHash"
+      }
+    },
+    "FunctionLevelLayerLambdaLayerS3Key": {
+      "Description": "Current Lambda layer S3Key",
+      "Value": "serverless/dd-sls-plugin-integration-test/dev/1635525038103-2021-10-29T16:30:38.103Z/FunctionLevelLayer.zip",
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-FunctionLevelLayerLambdaLayerS3Key"
       }
     },
     "PythonHello27LambdaFunctionQualifiedArn": {
@@ -821,15 +925,6 @@
         "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello10DashxLambdaFunctionQualifiedArn"
       }
     },
-    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
-      }
-    },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
@@ -846,6 +941,15 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-ExcludeThisLambdaFunctionQualifiedArn"
+      }
+    },
+    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
       }
     }
   }

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -209,7 +209,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/ProviderLevelLayer.zip"
         },
         "LayerName": "dd-sls-plugin-integration-test-dev-ProviderLevelLayer",
         "Description": "It's a text file",
@@ -225,7 +225,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/FunctionLevelLayer.zip"
         },
         "LayerName": "dd-sls-plugin-integration-test-dev-FunctionLevelLayer",
         "Description": "It's also a text file"

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -843,7 +843,7 @@
     },
     "ProviderLevelLayerLambdaLayerS3Key": {
       "Description": "Current Lambda layer S3Key",
-      "Value": "serverless/dd-sls-plugin-integration-test/dev/1635525038103-2021-10-29T16:30:38.103Z/ProviderLevelLayer.zip",
+      "Value": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/ProviderLevelLayer.zip",
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerS3Key"
       }
@@ -866,7 +866,7 @@
     },
     "FunctionLevelLayerLambdaLayerS3Key": {
       "Description": "Current Lambda layer S3Key",
-      "Value": "serverless/dd-sls-plugin-integration-test/dev/1635525038103-2021-10-29T16:30:38.103Z/FunctionLevelLayer.zip",
+      "Value": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/FunctionLevelLayer.zip",
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-FunctionLevelLayerLambdaLayerS3Key"
       }

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -1238,7 +1238,7 @@
           "S3Bucket": {
             "Ref": "ServerlessDeploymentBucket"
           },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/custom-resources.zip"
         },
         "FunctionName": "dd-sls-plugin-integration-test-dev-custom-resource-apigw-cw-role",
         "Handler": "apiGatewayCloudWatchRole/handler.handler",

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -8,6 +8,8 @@ provider:
   name: aws
   region: sa-east-1
   lambdaHashingVersion: 20201221
+  layers:
+    - { Ref: ProviderLevelLayerLambdaLayer }
 
 custom:
   datadog:
@@ -39,9 +41,22 @@ functions:
   JavascriptHello12-x:
     handler: js_handler.hello
     runtime: nodejs12.x
+    layers:
+      - { Ref: FunctionLevelLayerLambdaLayer }
   JavascriptHello14-x:
     handler: js_handler.hello
     runtime: nodejs14.x
   ExcludeThis:
     handler: js_handler.hello
     runtime: nodejs14.x
+layers:
+  ProviderLevelLayer:
+    path: ProviderLevelLayer # required, path to layer contents on disk
+    name: ${self:service}-${sls:stage}-ProviderLevelLayer # optional, Deployed Lambda layer name
+    description: It's a text file # optional, Description to publish to AWS
+    compatibleRuntimes: # optional, a list of runtimes this layer is compatible with
+      - nodejs12.x
+  FunctionLevelLayer:
+    path: FunctionLevelLayer
+    name: ${self:service}-${sls:stage}-FunctionLevelLayer # optional, Deployed Lambda layer name
+    description: It's also a text file # optional, Description to publish to AWS

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -39,7 +39,8 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
     echo "Running 'sls package' with ${SERVERLESS_CONFIGS[i]}"
     serverless package --config ${SERVERLESS_CONFIGS[i]}
     # Normalize S3Key timestamps
-    perl -p -i -e 's/("S3Key".*)/"S3Key": "serverless\/dd-sls-plugin-integration-test\/dev\/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX\/dd-sls-plugin-integration-test.zip"/g' ${RAW_CFN_TEMPLATE}
+    perl -p -i -e 's/("serverless\/dd-sls-plugin-integration-test\/dev\/.*\/dd-sls-plugin-integration-test.zip")/"serverless\/dd-sls-plugin-integration-test\/dev\/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX\/dd-sls-plugin-integration-test.zip"/g' ${RAW_CFN_TEMPLATE}
+    perl -p -i -e 's/("serverless\/dd-sls-plugin-integration-test\/dev\/.*\/custom-resources.zip")/"serverless\/dd-sls-plugin-integration-test\/dev\/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX\/custom-resources.zip"/g' ${RAW_CFN_TEMPLATE}
     # Normalize LambdaVersion ID's
     perl -p -i -e 's/(LambdaVersion.*")/LambdaVersionXXXX"/g' ${RAW_CFN_TEMPLATE}
     # Normalize SHA256 hashes

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -50,6 +50,9 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
     perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-(Python27|Python36|Python37|Python38|Python39|Node10-x|Node12-x|Node14-x|Extension):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-\2:XXX/g' ${RAW_CFN_TEMPLATE}
     # Normalize API Gateway timestamps
     perl -p -i -e 's/("ApiGatewayDeployment.*")/"ApiGatewayDeploymentxxxx"/g' ${RAW_CFN_TEMPLATE}
+    # Normalize layer timestamps
+    perl -p -i -e 's/("serverless\/dd-sls-plugin-integration-test\/dev\/.*\/ProviderLevelLayer.zip")/"serverless\/dd-sls-plugin-integration-test\/dev\/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX\/ProviderLevelLayer.zip"/g' ${RAW_CFN_TEMPLATE}
+    perl -p -i -e 's/("serverless\/dd-sls-plugin-integration-test\/dev\/.*\/FunctionLevelLayer.zip")/"serverless\/dd-sls-plugin-integration-test\/dev\/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX\/FunctionLevelLayer.zip"/g' ${RAW_CFN_TEMPLATE}
     cp ${RAW_CFN_TEMPLATE} ${TEST_SNAPSHOTS[i]}
     echo "===================================="
     if [ "$UPDATE_SNAPSHOTS" = "true" ]; then

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -311,14 +311,19 @@ describe("applyLambdaLibraryLayers", () => {
     const layers: LayerJSON = {
       regions: { "us-east-1": { "nodejs10.x": "node:2", extension: "extension:5" } },
     };
-    const mockService = createMockService("us-east-1", {
-      "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
-    });
+    const mockService = createMockService(
+      "us-east-1",
+      {
+        "node-function": { handler: "myfile.handler", runtime: "nodejs10.x" },
+      },
+      [],
+      ["my-layer-1", "my-layer-2"],
+    );
     applyLambdaLibraryLayers(mockService, [handler], layers);
     applyExtensionLayer(mockService, [handler], layers);
     expect(handler.handler).toEqual({
       runtime: "nodejs10.x",
-      layers: ["node:2", "extension:5"],
+      layers: ["my-layer-1", "my-layer-2", "node:2", "extension:5"],
     });
   });
 });

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -127,5 +127,5 @@ function getLayers(service: Service, handler: FunctionInfo): string[] {
 }
 
 function setLayers(handler: FunctionInfo, layers: string[]) {
-  (handler.handler as any).layers = layers;
+  (handler.handler as any).layers = [...new Set(layers)];
 }

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -113,15 +113,15 @@ export function isFunctionDefinitionHandler(funcDef: FunctionDefinition): funcDe
 
 function addLayer(service: Service, handler: FunctionInfo, layerArn: string) {
   const functionLayersList = ((handler.handler as any).layers as string[] | string[]) || [];
-  const serviceLayerList = ((service.provider as any).layers as string[] | string[]) || [];
+  const serviceLayersList = ((service.provider as any).layers as string[] | string[]) || [];
   // Function-level layers override service-level layers
   // Append to the function-level layers if other function-level layers are present
   // If service-level layers are present
   // Set them at the function level, as our layers are runtime-dependent and could vary
   // between functions in the same project
-  if (functionLayersList.length > 0 || serviceLayerList.length === 0) {
+  if (functionLayersList.length > 0 || serviceLayersList.length === 0) {
     (handler.handler as any).layers = pushLayerARN(layerArn, functionLayersList);
   } else {
-    (handler.handler as any).layers = pushLayerARN(layerArn, serviceLayerList);
+    (handler.handler as any).layers = pushLayerARN(layerArn, serviceLayersList);
   }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fixes #195, which was unveiled by #188 when we fixed another bug, where layers at the provider level were ignored.
The Serverless Framework does not merge provider-level layers with function-level layers. This can be reproduced with this configuration file:
```yaml
service: layer-test
frameworkVersion: "2"
provider:
  name: aws
  runtime: nodejs12.x
  lambdaHashingVersion: 20201221
  layers:
    - { Ref: MyLayerLambdaLayer } # This layer will be ignored

functions:
  hello:
    handler: handler.hello
    events:
      - httpApi:
          path: /hello
          method: get
    layers:
      - { Ref: FunctionLayerLambdaLayer } # This layer will be the only one used

layers:
  MyLayer:
    path: myLayer # required, path to layer contents on disk
    name: ${self:service}-${sls:stage}-layerName # optional, Deployed Lambda layer name
    description: It's a text file # optional, Description to publish to AWS
    compatibleRuntimes: # optional, a list of runtimes this layer is compatible with
      - nodejs12.x
  FunctionLayer:
    path: myFunctionLayer
    name: ${self:service}-${sls:stage}-function-layerName # optional, Deployed Lambda layer name
    description: It's also a text file # optional, Description to publish to AWS
    compatibleRuntimes: # optional, a list of runtimes this layer is compatible with
      - nodejs12.x
```

Therefore this change does the following:
- If service-level layers are present, and no function-level layers are present, we add layers (extension, library, or both) to the service-level
- If function-level layers are present, we add layers (extension, library, or both) to the function-level
- If both function-level and service-level layers are present, we add layers (extension, library, or both) to the function level.

We no longer merge customer layers at the service-level and function-level.

### Motivation
I was motivated by #195

### Testing Guidelines

Manual and automated testing

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
