### PR TITLE
updated lambda throttling monitor to reflect throttles not counting as invocations - changed to actual percentage

### DIFF
--- a/src/serverless_monitors.ts
+++ b/src/serverless_monitors.ts
@@ -58,9 +58,9 @@ export const HIGH_COLD_START_RATE: ServerlessMonitor = {
 
 export const HIGH_THROTTLES: ServerlessMonitor = {
   name: "High Throttles on {{functionname.name}} in {{region.name}} for {{aws_account.name}}",
-  threshold: 10,
+  threshold: 0.2,
   query: (cloudFormationStackId: string, criticalThreshold: number) => {
-    return `avg(last_15m):sum:aws.lambda.throttles {aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() / ( sum:aws.lambda.throttles {aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() + sum:aws.lambda.invocations{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() ) * 100 >= ${criticalThreshold}`;
+    return `avg(last_15m):sum:aws.lambda.throttles {aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() / ( sum:aws.lambda.throttles {aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() + sum:aws.lambda.invocations{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() ) >= ${criticalThreshold}`;
   },
   message:
     "More than 10% of invocations in the selected time range were throttled. Throttling occurs when your serverless Lambda applications receive high levels of traffic without adequate [concurrency](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html). {{#is_alert}} Resolution: Check your [Lambda concurrency metrics](https://docs.datadoghq.com/integrations/amazon_lambda/#metrics) and confirm if `aws.lambda.concurrent_executions.maximum` is approaching your AWS account concurrency level. If so, consider configuring reserved concurrency, or request a service quota increase from AWS. Note that this may affect your AWS bill. {{/is_alert}}",

--- a/src/serverless_monitors.ts
+++ b/src/serverless_monitors.ts
@@ -58,9 +58,9 @@ export const HIGH_COLD_START_RATE: ServerlessMonitor = {
 
 export const HIGH_THROTTLES: ServerlessMonitor = {
   name: "High Throttles on {{functionname.name}} in {{region.name}} for {{aws_account.name}}",
-  threshold: 0.2,
+  threshold: 10,
   query: (cloudFormationStackId: string, criticalThreshold: number) => {
-    return `avg(last_15m):sum:aws.lambda.throttles {aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() / sum:aws.lambda.invocations{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() >= ${criticalThreshold}`;
+    return `avg(last_15m):sum:aws.lambda.throttles {aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() / ( sum:aws.lambda.throttles {aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() + sum:aws.lambda.invocations{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() ) * 100 >= ${criticalThreshold}`;
   },
   message:
     "More than 10% of invocations in the selected time range were throttled. Throttling occurs when your serverless Lambda applications receive high levels of traffic without adequate [concurrency](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html). {{#is_alert}} Resolution: Check your [Lambda concurrency metrics](https://docs.datadoghq.com/integrations/amazon_lambda/#metrics) and confirm if `aws.lambda.concurrent_executions.maximum` is approaching your AWS account concurrency level. If so, consider configuring reserved concurrency, or request a service quota increase from AWS. Note that this may affect your AWS bill. {{/is_alert}}",


### PR DESCRIPTION
### What does this PR do?

As far as I can tell, a throttle does not count as an invocation, so to get the real percentage of throttles, you need to do
```
throttles / (throttles + invocations) * 100
```
(Also added *100 so we are dealing with actual percents)

### Motivation

Tried it for our projects and quickly realised something was wrong

### Testing Guidelines

Tested for a few days with existing live lambdas


### Types of changes

- [*] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [*] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
