### PR TITLE
 arm64 extension layer not applied to nodejs runtime fixes#210

### DIFF
--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -468,6 +468,36 @@ describe("applyLambdaLibraryLayers", () => {
     });
   });
 
+  it("adds correct lambda layer given architecture in provider level for node", () => {
+    const handler = {
+      handler: { runtime: "nodejs14.x" },
+      type: RuntimeType.NODE,
+      runtime: "nodejs14.x",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: {
+        "us-east-1": {
+          "nodejs14.x": "nodejs14.x",
+          extension: "extension:11",
+          "extension-arm": "extension-arm:11",
+        },
+      },
+    };
+    const mockService = createMockService(
+      "us-east-1",
+      {
+        "node-function": { handler: "myfile.handler", runtime: "nodejs14.x" },
+      },
+      "arm64",
+    );
+    applyLambdaLibraryLayers(mockService, [handler], layers);
+    applyExtensionLayer(mockService, [handler], layers);
+    expect(handler.handler).toEqual({
+      runtime: "nodejs14.x",
+      layers: ["nodejs14.x", "extension-arm:11"],
+    });
+  });
+
   it("uses default runtime layer if architecture not available for specified runtime", () => {
     const handler = {
       handler: { runtime: "python3.7", architecture: "arm64" },
@@ -495,7 +525,7 @@ describe("applyLambdaLibraryLayers", () => {
     expect(handler.handler).toEqual({
       architecture: "arm64",
       runtime: "python3.7",
-      layers: ["python:3.7", "extension:11"],
+      layers: ["python:3.7", "extension-arm:11"],
     });
   });
 

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -113,13 +113,12 @@ export function applyExtensionLayer(service: Service, handlers: FunctionInfo[], 
     if (handler.type === RuntimeType.UNSUPPORTED) {
       continue;
     }
-    const { runtime } = handler;
     const architecture =
       (handler.handler as any).architecture ?? (service.provider as any).architecture ?? DEFAULT_ARCHITECTURE;
     let extensionLayerARN: string | undefined;
     let extensionLayerKey: string = "extension";
 
-    if (architecture === ARM64_ARCHITECTURE && runtime && runtime in armRuntimeKeys) {
+    if (architecture === ARM64_ARCHITECTURE) {
       removePreviousLayer(service, handler, regionRuntimes[extensionLayerKey]);
       extensionLayerKey = armRuntimeKeys[extensionLayerKey];
     }


### PR DESCRIPTION
 - Use arm64 extensions layer when architecture is arm64 - don't check runtime architecture

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

When applying the extension layer, don't check the runtime architecture - nodejs just has 1 layer for both architectures. 

### Motivation

https://github.com/DataDog/serverless-plugin-datadog/issues/210

### Testing Guidelines

- Observed incorrect behavior in deployments - nodejs14.x with arm64 used x64 datadog extension layer. 
- Applied fix and deployed - x64 layer replaced with arm64 layer
- Re-created scenario in unit tests and passed unit tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
