### PR TITLE
Add support for Java runtime including environment variable and the tracing layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The plugin automatically enables instrumentation for applications to collect met
 
 ## Getting started
 
-To quickly get started, follow the installation instructions for [Python][1], [Node.js][2], [Ruby][3], [Java][4], [Go][5], or [.NET][6] and view your function's enhanced metrics, traces, and logs in Datadog. These instructions will get you a basic working setup. If working in Ruby, Java, or Go, further code changes are required.
+To quickly get started, follow the installation instructions for [Python][1], [Node.js][2], [Ruby][3], [Java][4], [Go][5], or [.NET][6] and view your function's enhanced metrics, traces, and logs in Datadog. These instructions will get you a basic working setup. If working in Ruby or Go, further code changes are required.
 
 ## Upgrade
 

--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -716,7 +716,8 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
           }
         },
         "Role": {
@@ -726,7 +727,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:XXX"
         ]
       },
       "DependsOn": [
@@ -770,7 +772,8 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
           }
         },
         "Role": {
@@ -780,7 +783,8 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:XXX"
         ]
       },
       "DependsOn": [

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -785,7 +785,8 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
           }
         },
         "Role": {
@@ -798,7 +799,8 @@
           {
             "Ref": "ProviderLevelLayerLambdaLayer"
           },
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:XXX"
         ]
       },
       "DependsOn": [
@@ -841,7 +843,8 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
           }
         },
         "Role": {
@@ -854,7 +857,8 @@
           {
             "Ref": "ProviderLevelLayerLambdaLayer"
           },
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:XXX"
         ]
       },
       "DependsOn": [

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -902,7 +902,8 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
           }
         },
         "Role": {
@@ -953,7 +954,8 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
           }
         },
         "Role": {

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet")
-JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "python3.6" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "extension" "extension-arm" "dotnet")
+LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-java")
+JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "python3.6" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "extension" "extension-arm" "dotnet" "java")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 FILE_NAME="src/layers.json"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -48,7 +48,7 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
     # Normalize dd_sls_plugin version tag value
     perl -p -i -e 's/(v\d+.\d+.\d+)/vX.XX.X/g' ${RAW_CFN_TEMPLATE}
     # Normalize Datadog Layer Arn versions
-    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:(Datadog-(Python36|Python37|Python38|Python39|Node12-x|Node14-x|Extension)|dd-trace-dotnet):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:\2:XXX/g' ${RAW_CFN_TEMPLATE}
+    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:(Datadog-(Python36|Python37|Python38|Python39|Node12-x|Node14-x|Extension)|dd-trace-dotnet|dd-trace-java):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:\2:XXX/g' ${RAW_CFN_TEMPLATE}
     # Normalize API Gateway timestamps
     perl -p -i -e 's/("ApiGatewayDeployment.*")/"ApiGatewayDeploymentxxxx"/g' ${RAW_CFN_TEMPLATE}
     # Normalize layer timestamps

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -476,6 +476,7 @@ describe("setEnvConfiguration", () => {
             DD_MERGE_XRAY_TRACES: true,
             DD_LOGS_INJECTION: false,
             DD_SERVERLESS_LOGS_ENABLED: true,
+            JAVA_TOOL_OPTIONS: "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1",
           },
           events: [],
         },

--- a/src/env.ts
+++ b/src/env.ts
@@ -96,6 +96,10 @@ const CORECLR_PROFILER = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
 const CORECLR_PROFILER_PATH = "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so";
 const DD_DOTNET_TRACER_HOME = "/opt/datadog";
 
+// Java tracer env variables
+const JAVA_TOOL_OPTIONS_VAR = "JAVA_TOOL_OPTIONS";
+const JAVA_TOOL_OPTIONS = "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1";
+
 export const ddTagsEnvVar = "DD_TAGS";
 
 export const defaultConfiguration: Configuration = {
@@ -195,6 +199,11 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
         environment[DOTNET_TRACER_HOME_ENV_VAR] = DD_DOTNET_TRACER_HOME;
       } else if (environment[DOTNET_TRACER_HOME_ENV_VAR] !== DD_DOTNET_TRACER_HOME) {
         throwEnvVariableError("DD_DOTNET_TRACER_HOME", DD_DOTNET_TRACER_HOME, functionName);
+      }
+    }
+    if (type == RuntimeType.JAVA) {
+      if (environment[JAVA_TOOL_OPTIONS_VAR] === undefined) {
+        environment[JAVA_TOOL_OPTIONS_VAR] = JAVA_TOOL_OPTIONS;
       }
     }
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -373,6 +373,144 @@ describe("ServerlessPlugin", () => {
     });
   });
 
+  it("Adds tracing layer for java11", async () => {
+    mock({});
+    const serverless = {
+      cli: {
+        log: () => {},
+      },
+      service: {
+        provider: {
+          region: "us-east-1",
+        },
+        functions: {
+          node1: {
+            handler: "my-func.ev",
+            layers: [],
+            runtime: "java11",
+          },
+        },
+        custom: {
+          datadog: {
+            apiKey: 1234,
+          },
+        },
+      },
+    };
+
+    const plugin = new ServerlessPlugin(serverless, {});
+    await plugin.hooks["after:package:initialize"]();
+    expect(serverless).toMatchObject({
+      service: {
+        functions: {
+          node1: {
+            handler: "my-func.ev",
+            layers: [
+              expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:Datadog-Extension\:.*/),
+              expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:dd-trace-java\:.*/),
+            ],
+            runtime: "java11",
+          },
+        },
+        provider: {
+          region: "us-east-1",
+        },
+      },
+    });
+  });
+
+  it("Adds tracing layer for java8.al2", async () => {
+    mock({});
+    const serverless = {
+      cli: {
+        log: () => {},
+      },
+      service: {
+        provider: {
+          region: "us-east-1",
+        },
+        functions: {
+          node1: {
+            handler: "my-func.ev",
+            layers: [],
+            runtime: "java8.al2",
+          },
+        },
+        custom: {
+          datadog: {
+            apiKey: 1234,
+          },
+        },
+      },
+    };
+
+    const plugin = new ServerlessPlugin(serverless, {});
+    await plugin.hooks["after:package:initialize"]();
+    expect(serverless).toMatchObject({
+      service: {
+        functions: {
+          node1: {
+            handler: "my-func.ev",
+            layers: [
+              expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:Datadog-Extension\:.*/),
+              expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:dd-trace-java\:.*/),
+            ],
+            runtime: "java8.al2",
+          },
+        },
+        provider: {
+          region: "us-east-1",
+        },
+      },
+    });
+  });
+
+  it("Adds tracing layer for java8", async () => {
+    mock({});
+    const serverless = {
+      cli: {
+        log: () => {},
+      },
+      service: {
+        provider: {
+          region: "us-east-1",
+        },
+        functions: {
+          node1: {
+            handler: "my-func.ev",
+            layers: [],
+            runtime: "java8",
+          },
+        },
+        custom: {
+          datadog: {
+            apiKey: 1234,
+          },
+        },
+      },
+    };
+
+    const plugin = new ServerlessPlugin(serverless, {});
+    await plugin.hooks["after:package:initialize"]();
+    expect(serverless).toMatchObject({
+      service: {
+        functions: {
+          node1: {
+            handler: "my-func.ev",
+            layers: [
+              expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:Datadog-Extension\:.*/),
+              expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:dd-trace-java\:.*/),
+            ],
+            runtime: "java8",
+          },
+        },
+        provider: {
+          region: "us-east-1",
+        },
+      },
+    });
+  });
+
   describe("validateConfiguration", () => {
     afterEach(() => {
       mock.restore();

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { newSimpleGit } from "./git";
 import {
   applyExtensionLayer,
   applyDotnetTracingLayer,
+  applyJavaTracingLayer,
   applyLambdaLibraryLayers,
   findHandlers,
   FunctionInfo,
@@ -119,6 +120,10 @@ module.exports = class ServerlessPlugin {
           this.serverless.cli.log("Adding .NET Tracing Layer to functions");
           this.debugLogHandlers(handlers);
           applyDotnetTracingLayer(this.serverless.service, functionInfo, allLayers);
+        } else if (functionInfo.type === RuntimeType.JAVA) {
+          this.serverless.cli.log("Adding Java Tracing Layer to functions");
+          this.debugLogHandlers(handlers);
+          applyJavaTracingLayer(this.serverless.service, functionInfo, allLayers);
         }
       });
     } else {

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -69,6 +69,7 @@ export const armRuntimeKeys: { [key: string]: string } = {
 };
 
 const dotnetTraceLayerKey: string = "dotnet";
+const javaTraceLayerKey: string = "java";
 
 export function findHandlers(service: Service, exclude: string[], defaultRuntime?: string): FunctionInfo[] {
   return Object.entries(service.functions)
@@ -152,6 +153,20 @@ export function applyDotnetTracingLayer(service: Service, handler: FunctionInfo,
   }
 
   const traceLayerARN: string | undefined = regionRuntimes[dotnetTraceLayerKey];
+
+  if (traceLayerARN) {
+    addLayer(service, handler, traceLayerARN);
+  }
+}
+
+export function applyJavaTracingLayer(service: Service, handler: FunctionInfo, layers: LayerJSON) {
+  const { region } = service.provider;
+  const regionRuntimes = layers.regions[region];
+  if (regionRuntimes === undefined) {
+    return;
+  }
+
+  const traceLayerARN: string | undefined = regionRuntimes[javaTraceLayerKey];
 
   if (traceLayerARN) {
     addLayer(service, handler, traceLayerARN);

--- a/src/layers.json
+++ b/src/layers.json
@@ -11,7 +11,8 @@
       "python3.9-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:4"
     },
     "eu-north-1": {
       "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:74",
@@ -24,7 +25,8 @@
       "python3.9-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:4"
     },
     "ap-south-1": {
       "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:74",
@@ -37,7 +39,8 @@
       "python3.9-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:4"
     },
     "eu-west-3": {
       "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:74",
@@ -50,7 +53,8 @@
       "python3.9-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:4"
     },
     "eu-west-2": {
       "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:74",
@@ -63,7 +67,8 @@
       "python3.9-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:4"
     },
     "eu-south-1": {
       "nodejs12.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node12-x:74",
@@ -76,7 +81,8 @@
       "python3.9-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:4"
     },
     "eu-west-1": {
       "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:74",
@@ -89,7 +95,8 @@
       "python3.9-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:4"
     },
     "ap-northeast-3": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Node12-x:74",
@@ -102,7 +109,8 @@
       "python3.9-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:4"
     },
     "ap-northeast-2": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:74",
@@ -115,7 +123,8 @@
       "python3.9-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:4"
     },
     "me-south-1": {
       "nodejs12.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node12-x:74",
@@ -128,7 +137,8 @@
       "python3.9-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:4"
     },
     "ap-northeast-1": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:74",
@@ -141,7 +151,8 @@
       "python3.9-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:4"
     },
     "sa-east-1": {
       "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:74",
@@ -154,7 +165,8 @@
       "python3.9-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:4"
     },
     "ca-central-1": {
       "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:74",
@@ -167,7 +179,8 @@
       "python3.9-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:4"
     },
     "ap-east-1": {
       "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:74",
@@ -180,7 +193,8 @@
       "python3.9-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:4"
     },
     "ap-southeast-1": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:74",
@@ -193,7 +207,8 @@
       "python3.9-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:4"
     },
     "ap-southeast-2": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:74",
@@ -206,7 +221,8 @@
       "python3.9-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:4"
     },
     "eu-central-1": {
       "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:74",
@@ -219,7 +235,8 @@
       "python3.9-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:4"
     },
     "us-east-1": {
       "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:74",
@@ -232,7 +249,8 @@
       "python3.9-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:4"
     },
     "us-east-2": {
       "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:74",
@@ -245,7 +263,8 @@
       "python3.9-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:4"
     },
     "us-west-1": {
       "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:74",
@@ -258,7 +277,8 @@
       "python3.9-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:4"
     },
     "us-west-2": {
       "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:74",
@@ -271,7 +291,8 @@
       "python3.9-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python39-ARM:53",
       "extension": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:21",
       "extension-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:21",
-      "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet:1"
+      "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet:1",
+      "java": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-java:4"
     }
   }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Based on the #238 from @lizapressman, I've also added the necessary environment variables and the tracing layer for Java.

### Motivation

Direct support for Java

### Testing Guidelines

We're testing this in our environment, so far everything looks good.

### Additional Notes

See #238 for more details

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
