### PR TITLE
[SLS-1361] Use DD_XXX env vars for tagging

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -263,6 +263,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -319,6 +321,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -375,6 +379,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -431,6 +437,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -487,6 +495,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "js_handler.hello"
           }
         },
@@ -543,6 +553,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "js_handler.hello"
           }
         },
@@ -602,7 +614,9 @@
             "CORECLR_ENABLE_PROFILING": "1",
             "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
             "CORECLR_PROFILER_PATH": "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so",
-            "DD_DOTNET_TRACER_HOME": "/opt/datadog"
+            "DD_DOTNET_TRACER_HOME": "/opt/datadog",
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -661,7 +675,9 @@
             "CORECLR_ENABLE_PROFILING": "1",
             "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
             "CORECLR_PROFILER_PATH": "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so",
-            "DD_DOTNET_TRACER_HOME": "/opt/datadog"
+            "DD_DOTNET_TRACER_HOME": "/opt/datadog",
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -718,7 +734,9 @@
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
             "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1",
-            "DD_JMXFETCH_ENABLED": false
+            "DD_JMXFETCH_ENABLED": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -775,7 +793,9 @@
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
             "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1",
-            "DD_JMXFETCH_ENABLED": false
+            "DD_JMXFETCH_ENABLED": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -830,7 +850,9 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -267,14 +267,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -286,6 +278,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -325,14 +319,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -344,6 +330,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -383,14 +371,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -402,6 +382,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -441,14 +423,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -460,6 +434,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "py_handler.hello"
           }
         },
@@ -499,14 +475,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -518,6 +486,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "js_handler.hello"
           }
         },
@@ -557,14 +527,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -576,6 +538,8 @@
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
             "DD_LAMBDA_HANDLER": "js_handler.hello"
           }
         },
@@ -611,6 +575,9 @@
         "FunctionName": "dd-sls-plugin-integration-test-dev-ExcludeThis",
         "MemorySize": 1024,
         "Timeout": 6,
+        "Environment": {
+          "Variables": {}
+        },
         "Role": {
           "Fn::GetAtt": [
             "IamRoleLambdaExecution",
@@ -645,14 +612,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -667,7 +626,9 @@
             "CORECLR_ENABLE_PROFILING": "1",
             "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
             "CORECLR_PROFILER_PATH": "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so",
-            "DD_DOTNET_TRACER_HOME": "/opt/datadog"
+            "DD_DOTNET_TRACER_HOME": "/opt/datadog",
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -706,14 +667,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -728,7 +681,9 @@
             "CORECLR_ENABLE_PROFILING": "1",
             "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
             "CORECLR_PROFILER_PATH": "/opt/datadog/Datadog.Trace.ClrProfiler.Native.so",
-            "DD_DOTNET_TRACER_HOME": "/opt/datadog"
+            "DD_DOTNET_TRACER_HOME": "/opt/datadog",
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -767,14 +722,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -787,7 +734,9 @@
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
             "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1",
-            "DD_JMXFETCH_ENABLED": false
+            "DD_JMXFETCH_ENABLED": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -826,14 +775,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -846,7 +787,9 @@
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
             "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1",
-            "DD_JMXFETCH_ENABLED": false
+            "DD_JMXFETCH_ENABLED": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {
@@ -885,14 +828,6 @@
           {
             "Key": "dd_sls_plugin",
             "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
           }
         ],
         "Environment": {
@@ -903,7 +838,9 @@
             "DD_MERGE_XRAY_TRACES": false,
             "DD_LOGS_INJECTION": true,
             "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
           }
         },
         "Role": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -88,6 +88,11 @@ const logInjectionEnvVar = "DD_LOGS_INJECTION";
 const ddLogsEnabledEnvVar = "DD_SERVERLESS_LOGS_ENABLED";
 const ddCaptureLambdaPayloadEnvVar = "DD_CAPTURE_LAMBDA_PAYLOAD";
 
+export const ddServiceEnvVar = "DD_SERVICE";
+export const ddEnvEnvVar = "DD_ENV";
+export const ddVersionEnvVar = "DD_VERSION";
+export const ddTagsEnvVar = "DD_TAGS";
+
 // .NET tracer env variables
 const ENABLE_PROFILING_ENV_VAR = "CORECLR_ENABLE_PROFILING";
 const PROFILER_ENV_VAR = "CORECLR_PROFILER";
@@ -102,8 +107,6 @@ const DD_DOTNET_TRACER_HOME = "/opt/datadog";
 const JAVA_TOOL_OPTIONS_VAR = "JAVA_TOOL_OPTIONS";
 const JAVA_TOOL_OPTIONS = '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1';
 const JAVA_JMXFETCH_ENABLED_VAR = "DD_JMXFETCH_ENABLED";
-
-export const ddTagsEnvVar = "DD_TAGS";
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -63,7 +63,9 @@ describe("ServerlessPlugin", () => {
         cli: {
           log: () => {},
         },
+        getProvider: (_name: string) => awsMock(),
         service: {
+          getServiceName: () => "dev",
           provider: {
             region: "us-east-1",
           },
@@ -108,7 +110,9 @@ describe("ServerlessPlugin", () => {
         cli: {
           log: () => {},
         },
+        getProvider: (_name: string) => awsMock(),
         service: {
+          getServiceName: () => "dev",
           provider: {
             region: "us-east-1",
           },
@@ -153,7 +157,9 @@ describe("ServerlessPlugin", () => {
         cli: {
           log: () => {},
         },
+        getProvider: (_name: string) => awsMock(),
         service: {
+          getServiceName: () => "dev",
           provider: {
             region: "us-east-1",
           },
@@ -201,7 +207,9 @@ describe("ServerlessPlugin", () => {
         cli: {
           log: () => {},
         },
+        getProvider: (_name: string) => awsMock(),
         service: {
+          getServiceName: () => "dev",
           provider: {
             region: "us-east-1",
           },
@@ -290,7 +298,9 @@ describe("ServerlessPlugin", () => {
         cli: {
           log: () => {},
         },
+        getProvider: (_name: string) => awsMock(),
         service: {
+          getServiceName: () => "dev",
           provider: {
             region: "us-east-1",
           },
@@ -342,7 +352,9 @@ describe("ServerlessPlugin", () => {
       cli: {
         log: () => {},
       },
+      getProvider: (_name: string) => awsMock(),
       service: {
+        getServiceName: () => "dev",
         provider: {
           region: "us-east-1",
         },
@@ -388,7 +400,9 @@ describe("ServerlessPlugin", () => {
       cli: {
         log: () => {},
       },
+      getProvider: (_name: string) => awsMock(),
       service: {
+        getServiceName: () => "dev",
         provider: {
           region: "us-east-1",
         },
@@ -434,7 +448,9 @@ describe("ServerlessPlugin", () => {
       cli: {
         log: () => {},
       },
+      getProvider: (_name: string) => awsMock(),
       service: {
+        getServiceName: () => "dev",
         provider: {
           region: "us-east-1",
         },
@@ -480,7 +496,9 @@ describe("ServerlessPlugin", () => {
       cli: {
         log: () => {},
       },
+      getProvider: (_name: string) => awsMock(),
       service: {
+        getServiceName: () => "dev",
         provider: {
           region: "us-east-1",
         },
@@ -785,7 +803,9 @@ describe("ServerlessPlugin", () => {
       cli: {
         log: () => {},
       },
+      getProvider: (_name: string) => awsMock(),
       service: {
+        getServiceName: () => "dev",
         provider: {
           region: "us-east-1",
         },
@@ -821,7 +841,9 @@ describe("ServerlessPlugin", () => {
       cli: {
         log: () => {},
       },
+      getProvider: (_name: string) => awsMock(),
       service: {
+        getServiceName: () => "dev",
         provider: {
           region: "us-east-1",
         },
@@ -1206,7 +1228,7 @@ describe("ServerlessPlugin", () => {
       });
     });
 
-    it("adds tags by default with service name and stage values", async () => {
+    it("adds tags by default with service name and stage values when using forwarder", async () => {
       const function_ = functionMock({});
       const serverless = {
         cli: { log: () => {} },
@@ -1220,6 +1242,11 @@ describe("ServerlessPlugin", () => {
           },
           functions: {
             node1: function_,
+          },
+          custom: {
+            datadog: {
+              forwarderArn: "some-arn",
+            },
           },
         },
       };
@@ -1246,6 +1273,11 @@ describe("ServerlessPlugin", () => {
           },
           functions: {
             node1: function_,
+          },
+          custom: {
+            datadog: {
+              forwarderArn: "some-arn",
+            },
           },
         },
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ module.exports = class ServerlessPlugin {
     }
 
     if (config.addExtension) {
-      this.serverless.cli.log("Adding DD_XXX Env Vars");
+      this.serverless.cli.log("Adding Datadog Env Vars");
       this.addDDEnvVars(handlers);
     }
     if (config.forwarderArn !== undefined || config.forwarderArn !== undefined) {
@@ -185,6 +185,12 @@ module.exports = class ServerlessPlugin {
       for (const error of errors) {
         this.serverless.cli.log(error);
       }
+    }
+
+    if (datadogForwarderArn && config.addExtension) {
+      this.serverless.cli.log(
+        "Warning: Datadog Lambda Extension and forwarder are both enabled. Only APIGateway log groups will be subscribed to the forwarder.",
+      );
     }
 
     this.addTags(handlers, config.enableTags, datadogForwarderArn !== undefined);

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,7 @@ module.exports = class ServerlessPlugin {
    * If these don't already exsist on the function level as env vars, adds them as DD_XXX env vars
    */
   private addDDEnvVars(handlers: FunctionInfo[]) {
+    const provider = this.serverless.service.provider as any;
     const service = this.serverless.service as any;
 
     let custom = service.custom as any;
@@ -285,21 +286,23 @@ module.exports = class ServerlessPlugin {
     handlers.forEach(({ handler }) => {
       handler.environment ??= {};
       const environment = handler.environment as any;
+      provider.environment ??= {};
+      const providerEnvironment = provider.environment as any;
 
       if (custom?.datadog?.service !== undefined && environment[ddServiceEnvVar] === undefined) {
-        environment[ddServiceEnvVar] = custom.datadog.service;
+        environment[ddServiceEnvVar] = providerEnvironment[ddServiceEnvVar] ?? custom.datadog.service;
       }
 
       if (custom?.datadog?.env !== undefined && environment[ddEnvEnvVar] === undefined) {
-        environment[ddEnvEnvVar] = custom.datadog.env;
+        environment[ddEnvEnvVar] = providerEnvironment[ddEnvEnvVar] ?? custom.datadog.env;
       }
 
       if (custom?.datadog?.version !== undefined && environment[ddVersionEnvVar] === undefined) {
-        environment[ddVersionEnvVar] = custom.datadog.version;
+        environment[ddVersionEnvVar] = providerEnvironment[ddVersionEnvVar] ?? custom.datadog.version;
       }
 
       if (custom?.datadog?.tags !== undefined && environment[ddTagsEnvVar] === undefined) {
-        environment[ddTagsEnvVar] = custom.datadog.tags;
+        environment[ddTagsEnvVar] = providerEnvironment[ddTagsEnvVar] ?? custom.datadog.tags;
       }
 
       // default to service and stage if env vars aren't set
@@ -341,7 +344,7 @@ module.exports = class ServerlessPlugin {
         tagsArray.forEach((tag: string) => {
           const key = tag.split(":")[0];
           const value = tag.split(":")[1];
-          if (key && value && tags[key] !== undefined) {
+          if (key && value && tags[key] === undefined) {
             tags[key] = value;
           }
         });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Allows for user to set tags for env, service, version, and tags under custom.datadog in their `serverless.yml` files that get translated to DD_XXX environment variables if using the extension and added as tags if using the forwarder.

If DD_XXX is specifically set at the provider or function level, that env var will not be overwritten. 

We also no longer set service and env tags if using the extension and not the forwarder. Instead these will be set as DD_ENV and DD_SERVICE environment variables that are still taken from the provider level (if not provided)

Also adds a warning message if a customer is using both forwarder and extension.

### Motivation

<!--- What inspired you to submit this pull request? --->
https://datadoghq.atlassian.net/browse/SLS-1361

### Testing Guidelines

<!--- How did you test this pull request? --->
Tested all the edge cases I could think of by deploying a [test python function](https://sa-east-1.console.aws.amazon.com/lambda/home?region=sa-east-1#/functions/liza-sls-testing-dev-hello_python36?tab=configure). Everything looked okay to me. 

### Additional Notes

<!--- Anything else we should know when reviewing? --->
It looks like support for DD_ENV, DD_SERVICE, and DD_VERSION were added in [v10](https://github.com/DataDog/datadog-lambda-extension/releases/tag/v10) of the extension and I believe DD_TAGS got support in [v9](https://github.com/DataDog/datadog-lambda-extension/releases/tag/v9) so anything using v9 or lower of the extension would break with these changes

### Types of changes

- [ ] Bug fix
- [x] New feature
- [x] Breaking change (For versions 9 or lower of the extension)
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
