### PR TITLE
Don't configure tracing for external API Gateway

### DIFF
--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -23,7 +23,7 @@ export function enableTracing(service: Service, tracingMode: TracingMode, handle
   const provider = service.provider as any;
   if (tracingMode === TracingMode.XRAY || tracingMode === TracingMode.HYBRID) {
     provider.tracing = {
-      apiGateway: service.provider.apiGateway.restApiId ? null : true,
+      apiGateway: service.provider['apiGateway']?.restApiId ? null : true,
       lambda: true,
     };
   }

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -23,7 +23,7 @@ export function enableTracing(service: Service, tracingMode: TracingMode, handle
   const provider = service.provider as any;
   if (tracingMode === TracingMode.XRAY || tracingMode === TracingMode.HYBRID) {
     provider.tracing = {
-      apiGateway: true,
+      apiGateway: service.provider.apiGateway.restApiId ? null : true,
       lambda: true,
     };
   }

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -7,6 +7,7 @@
  */
 
 import Service from "serverless/classes/Service";
+import { Provider } from "serverless/plugins/aws/provider/awsProvider";
 import { FunctionInfo } from "./layer";
 
 const ddTraceEnabledEnvVar = "DD_TRACE_ENABLED";
@@ -20,10 +21,12 @@ export enum TracingMode {
 }
 
 export function enableTracing(service: Service, tracingMode: TracingMode, handlers: FunctionInfo[]) {
-  const provider = service.provider as any;
+  const provider = service.provider as Provider;
   if (tracingMode === TracingMode.XRAY || tracingMode === TracingMode.HYBRID) {
     provider.tracing = {
-      apiGateway: service.provider['apiGateway']?.restApiId ? null : true,
+      apiGateway: provider.apiGateway?.restApiId
+        ? (undefined as any) // Current type definition does not allow undefined however it is a valid option.
+        : true,
       lambda: true,
     };
   }


### PR DESCRIPTION
Without this change deploy fails with the following error:

```
When external API Gateway resource is imported via "provider.apiGateway.restApiId", property "provider.tracing.apiGateway" is ineffective.
```

From the [serverless documentation](https://www.serverless.com/framework/docs/deprecations#aws-api-gateway-schemas):

> When external API Gateway resource is used and imported via provider.apiGateway.restApiId setting, both provider.logs.restApi and provider.tracing.apiGateway are ignored. In v3, an error will be thrown if these options are defined. Indeed, these settings are applicable only if API Gateway resource is provisioned by Serverless Framework.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
