### PR TITLE
Fix unit tests in the serverless plugin

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -92,7 +92,7 @@ describe("ServerlessPlugin", () => {
               handler: "my-func.ev",
               layers: [
                 expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:.*/),
-                "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:22",
+                expect.stringMatching(/arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:(.*)*/),
               ],
               runtime: "nodejs14.x",
             },


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

We released v23 of the extension and the test is expecting v22. I've removed the version check to ensure that this test doesn't fail whenever we release a new version. I think this is okay because we're still checking to see if the extension was added, we're just not checking if it's the latest version anymore.

Example failing test: https://github.com/DataDog/serverless-plugin-datadog/runs/6869440265?check_suite_focus=true#step:7:62

### Motivation

Broken test

### Testing Guidelines

`yarn test` passes

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
