### PR TITLE
Disable DD runtime metrics for Java

### DIFF
--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -975,7 +975,8 @@
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
             "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1",
-            "DD_JMXFETCH_ENABLED": false
+            "DD_JMXFETCH_ENABLED": false,
+            "DD_RUNTIME_METRICS_ENABLED": false
           }
         },
         "Role": {
@@ -1028,7 +1029,8 @@
             "DD_SERVERLESS_LOGS_ENABLED": true,
             "DD_CAPTURE_LAMBDA_PAYLOAD": false,
             "JAVA_TOOL_OPTIONS": "-javaagent:\"/opt/java/lib/dd-java-agent.jar\" -XX:+TieredCompilation -XX:TieredStopAtLevel=1",
-            "DD_JMXFETCH_ENABLED": false
+            "DD_JMXFETCH_ENABLED": false,
+            "DD_RUNTIME_METRICS_ENABLED": false
           }
         },
         "Role": {

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -489,6 +489,7 @@ describe("setEnvConfiguration", () => {
             JAVA_TOOL_OPTIONS:
               '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1',
             DD_JMXFETCH_ENABLED: false,
+            DD_RUNTIME_METRICS_ENABLED: false,
           },
           events: [],
         },

--- a/src/env.ts
+++ b/src/env.ts
@@ -110,6 +110,8 @@ const JAVA_TOOL_OPTIONS_VAR = "JAVA_TOOL_OPTIONS";
 const JAVA_TOOL_OPTIONS = '-javaagent:"/opt/java/lib/dd-java-agent.jar" -XX:+TieredCompilation -XX:TieredStopAtLevel=1';
 const JAVA_JMXFETCH_ENABLED_VAR = "DD_JMXFETCH_ENABLED";
 const JAVA_JMXFETCH_ENABLED = false;
+const JAVA_RUNTIME_METRICS_ENABLED_VAR = "DD_RUNTIME_METRICS_ENABLED";
+const JAVA_RUNTIME_METRICS_ENABLED = false;
 
 export const defaultConfiguration: Configuration = {
   addLayers: true,
@@ -222,6 +224,11 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
         environment[JAVA_JMXFETCH_ENABLED_VAR] = JAVA_JMXFETCH_ENABLED;
       } else if (environment[JAVA_JMXFETCH_ENABLED_VAR] !== JAVA_JMXFETCH_ENABLED) {
         throwEnvVariableError("DD_JMXFETCH_ENABLED", `${JAVA_JMXFETCH_ENABLED}`, functionName);
+      }
+      if (environment[JAVA_RUNTIME_METRICS_ENABLED_VAR] === undefined) {
+        environment[JAVA_RUNTIME_METRICS_ENABLED_VAR] = JAVA_RUNTIME_METRICS_ENABLED;
+      } else if (environment[JAVA_RUNTIME_METRICS_ENABLED_VAR] !== JAVA_RUNTIME_METRICS_ENABLED) {
+        throwEnvVariableError("DD_RUNTIME_METRICS_ENABLED", `${JAVA_RUNTIME_METRICS_ENABLED}`, functionName);
       }
     }
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -92,7 +92,7 @@ describe("ServerlessPlugin", () => {
               handler: "my-func.ev",
               layers: [
                 expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:.*/),
-                "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:22",
+                "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:23",
               ],
               runtime: "nodejs14.x",
             },


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR disables the DD runtime metrics for Java by setting the environment variable `DD_RUNTIME_METRICS_ENABLED` to `false` by default, as this is not supported and leads to runtime errors when not set. Please also see @maxday comment in my issue https://github.com/DataDog/datadog-lambda-java/issues/78#issuecomment-1103092782 for more details.

### Motivation

Not settings this by default is error-prone and can be easily be misinterpreted.

### Testing Guidelines

I've extended the existing tests and tested this plugin with a Java lambda deployment.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
