### PR TITLE
Show better Monitor errors

### DIFF
--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -22,6 +22,7 @@ export async function createMonitor(
   monitorParams: MonitorParams,
   monitorsApiKey: string,
   monitorsAppKey: string,
+  serverlessMonitorId: string,
 ) {
   const response: Response = await fetch(`https://api.${site}/api/v1/monitor`, {
     method: "POST",
@@ -33,6 +34,12 @@ export async function createMonitor(
     body: JSON.stringify(monitorParams),
   });
 
+  if (response.status !== 200) {
+    const responseText = await response.text();
+    throw new Error(
+      `${response.status} ${response.statusText} for monitor ${serverlessMonitorId}. Response from Monitors API:\n\t${responseText}`,
+    );
+  }
   return response;
 }
 
@@ -42,6 +49,7 @@ export async function updateMonitor(
   monitorParams: MonitorParams,
   monitorsApiKey: string,
   monitorsAppKey: string,
+  serverlessMonitorId: string,
 ) {
   const response: Response = await fetch(`https://api.${site}/api/v1/monitor/${monitorId}`, {
     method: "PUT",
@@ -52,6 +60,13 @@ export async function updateMonitor(
     },
     body: JSON.stringify(monitorParams),
   });
+
+  if (response.status !== 200) {
+    const responseText = await response.text();
+    throw new Error(
+      `${response.status} ${response.statusText} for monitor ${serverlessMonitorId}. Response from Monitors API: \n\t${responseText}`,
+    );
+  }
 
   return response;
 }

--- a/src/monitors.ts
+++ b/src/monitors.ts
@@ -125,7 +125,18 @@ export function handleMonitorsApiResponse(response: Response, serverlessMonitorI
   if (response.status === 200) {
     return true;
   } else if (response.status === 400) {
-    throw new Error(`400 Bad Request: This could be due to incorrect syntax for ${serverlessMonitorId}`);
+    //If the Monitors API returns a bad status, its response will be {"errors": ["an array of strings describing the errors"]}
+    type MonitorsAPIErrorResponse = { errors: [string] };
+
+    let errMessage = "";
+    response.json().then((value) => {
+      const monitorsResponse = <MonitorsAPIErrorResponse>value;
+      monitorsResponse.errors.forEach((err) => {
+        errMessage = errMessage + "\t" + err + "\n";
+      });
+    });
+
+    throw new Error(`400 Bad Request for monitor ${serverlessMonitorId}. Monitors API response:\n${errMessage}`);
   } else {
     throw new Error(`${response.status} ${response.statusText}`);
   }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

The Monitors API gives us nice human readable errors when we try to create a monitor but have a bad request. We should show these errors to the user as opposed to suppressing them, This can be helpful for the end user, or at the very least will aid in troubleshooting. 

I removed `handleMonitorsApiResponse` since all that does is return true or throw an exception. I moved the exception throwing into `create/updateMonitor` since those are already async, and replaced `handleMonitorsApiResponse` with a check for `response.status === 200`. 

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
