### PR TITLE
Add warning message if users use -f option when sls deploy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,6 @@ import { addOutputLinks, printOutputs } from "./output";
 import { SourceCodeIntegration } from "./source-code-integration";
 import { enableTracing, TracingMode } from "./tracing";
 import { redirectHandlers } from "./wrapper";
-const { log } = require('@serverless/utils/log');
 
 // Separate interface since DefinitelyTyped currently doesn't include tags or env
 export interface ExtendedFunctionDefinition extends FunctionDefinition {
@@ -93,8 +92,7 @@ module.exports = class ServerlessPlugin {
 
   private cliSharedInitialize() {
     if (this.options!.function) {
-      log.warn("Using serverless deploy -f option only updates the function code and will not update CloudFormation stack (env variables included).")
-      log.debug("serverless CLI options:", this.options)
+      this.serverless.cli.log("Warning: Using serverless deploy -f option only updates the function code and will not update CloudFormation stack (env variables included).")
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ enum TagKeys {
 
 module.exports = class ServerlessPlugin {
   public hooks = {
-    "initialize": this.cliSharedInitialize.bind(this),
+    initialize: this.cliSharedInitialize.bind(this),
     "after:datadog:clean:init": this.afterPackageFunction.bind(this),
     "after:datadog:generate:init": this.beforePackageFunction.bind(this),
     "after:deploy:function:packageFunction": this.afterPackageFunction.bind(this),

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,12 +87,13 @@ module.exports = class ServerlessPlugin {
       usage: "Automatically instruments your lambdas with DataDog",
     },
   };
-  constructor(private serverless: Serverless,
-              private options: Serverless.Options) {}
+  constructor(private serverless: Serverless, private options: Serverless.Options) {}
 
   private cliSharedInitialize() {
     if (this.options!.function) {
-      this.serverless.cli.log("Warning: Using serverless deploy -f option only updates the function code and will not update CloudFormation stack (env variables included).")
+      this.serverless.cli.log(
+        "Warning: Using serverless deploy -f option only updates the function code and will not update CloudFormation stack (env variables included).",
+      );
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ module.exports = class ServerlessPlugin {
 
   private cliSharedInitialize() {
     if (this.options!.function) {
-      log.warn("========= using serverless deploy -f option only updates the function code and will not update CloudFormation stack (env variables included).")
+      log.warn("Using serverless deploy -f option only updates the function code and will not update CloudFormation stack (env variables included).")
       log.debug("serverless CLI options:", this.options)
     }
   }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Add warning message when users use `sls deploy -f` to specify specific to deploy. Because `-f` flag would only deploy function code not the entire CF stack, the env variables would not be updated.

The warning is added so that whenever a serverless CLI runs and `-f` is specified, the warning message shows up.
(docs on the `initialize` hook https://www.serverless.com/framework/docs/guides/plugins/creating-plugins#lifecycle-events)

<!--- A brief description of the change being made with this pull request. --->

### Motivation
https://datadoghq.atlassian.net/browse/SLS-2401
A client faced this issue when upgrading plug-in version and raised an issue before.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Tested locally. But cannot deploy to sandbox because of error: `Request must be smaller than 69905067 bytes for the UpdateFunctionCode operation`, probably the function code is too big.

From looking at the command line pre-deploy, the change should be good.
<img width="1545" alt="image" src="https://user-images.githubusercontent.com/47579703/180897936-bfccaed6-d68b-450c-8c0e-58dd399f50da.png">

No unit tests added because there are no tests for other life cycle functions. And this is the most basic function.
<!--- How did you test this pull request? --->

### Additional Notes
reference: https://www.serverless.com/framework/docs/guides/plugins/cli-output


<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
