### PR TITLE
[SLS-2142] Remove old function detail page link

### DIFF
--- a/src/output.ts
+++ b/src/output.ts
@@ -28,7 +28,7 @@ export async function addOutputLinks(
     const key = `${outputPrefix}${name}`.replace(/[^a-z0-9]/gi, "");
     outputs[key] = {
       Description: `See ${name} in Datadog`,
-      Value: `https://${subdomain}.${site}/functions/${functionName}:${region}:${awsAccount}:aws?source=sls-plugin`,
+      Value: `https://${subdomain}.${site}/functions?selection=aws-lambda-functions%2B${functionName?.toLowerCase()}%2B${region}%2B${awsAccount}`,
     };
   });
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Replace the function detail page link with a link to the lambda side panel

### Motivation

<!--- What inspired you to submit this pull request? --->
https://datadoghq.atlassian.net/browse/SLS-2142

### Testing Guidelines

<!--- How did you test this pull request? --->
Linked the changes, deployed a lambda function, and tested the new link.
<img width="809" alt="Screen Shot 2022-08-18 at 10 10 47 AM" src="https://user-images.githubusercontent.com/35850765/185416248-47aebdd3-3be2-40eb-ae14-4b2b3c5dc675.png">

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
