### PR TITLE
Fix integration test flakiness

### DIFF
--- a/scripts/compare_snapshots.py
+++ b/scripts/compare_snapshots.py
@@ -1,0 +1,88 @@
+import json
+import sys
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def compare_without_order(a, b, file_name_a, file_name_b):
+    """Compare objects a and b, ignoring order if the types are dicts or sortable arrays
+    """
+    aType = type(a)
+    bType = type(b)
+    if aType != bType:
+        log.warning("Mismatch: Objects have different types: %s vs %s", aType, bType)
+        return False
+
+    if aType == dict:
+        if len(a) != len(b):
+            log.warning("Mismatch: Dicts have different lengths (%s vs %s). a_keys=%s vs b_keys=%s", len(a), len(b), a.keys(), b.keys())
+            return False
+        for key in a:
+            a_value = a[key]
+            b_value = b.get(key)
+
+            if b_value is None:
+                log.warning("Mismatch: Key %s present in %s but missing from %s dict with keys %s", key, file_name_a, file_name_b, b.keys())
+                return False
+
+            if not compare_without_order(a_value, b_value, file_name_a, file_name_b):
+                log.warning("Mismatch: Dict values at key %s do not match", key)
+                return False
+
+        return True
+
+    if aType == list:
+        if len(a) != len(b):
+            log.warning("Mismatch: Arrays have different lengths (%s vs %s)", len(a), len(b))
+            return False
+
+        # Try sorting arrays but fall back to the original order if there's no
+        # builtin comparison fn
+        try:
+            sorted_a = sorted(a)
+            sorted_b = sorted(b)
+        except TypeError:
+            sorted_a = a
+            sorted_b = b
+
+        for i in range(len(a)):
+            aListItem = sorted_a[i]
+            bListItem = sorted_b[i]
+
+            if not compare_without_order(aListItem, bListItem, file_name_a, file_name_b):
+                log.warning("Mismatch: Array items at position %s do not match", i)
+                return False
+
+        return True
+
+    do_objects_match = a == b
+    if not do_objects_match:
+        log.warning("Values %s and %s do not match", a, b)
+    return do_objects_match
+
+
+def compare_json_files_without_order(file_name_a, file_name_b):
+    with open(file_name_a) as fileA:
+        file_a_data = json.load(fileA)
+    
+    with open(file_name_b) as fileB:
+        file_b_data = json.load(fileB)
+
+    return compare_without_order(file_a_data, file_b_data, file_name_a, file_name_b)
+
+
+def main(): 
+    if (len(sys.argv) != 3):
+        raise ValueError("Must provide 2 file names to compare")
+    
+    do_snapshots_match = compare_json_files_without_order(sys.argv[1], sys.argv[2])
+
+    if not do_snapshots_match:
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_snapshots.py
+++ b/scripts/compare_snapshots.py
@@ -81,11 +81,10 @@ def main():
     if len(sys.argv) != 3:
         raise ValueError("Must provide 2 file names to compare")
 
-    do_snapshots_match = do_json_files_match(sys.argv[1], sys.argv[2])
-
-    if not do_snapshots_match:
+    if not do_json_files_match(sys.argv[1], sys.argv[2]):
         sys.exit(1)
 
+    # Exit successfully if no mismatch found
     sys.exit(0)
 
 

--- a/scripts/compare_snapshots.py
+++ b/scripts/compare_snapshots.py
@@ -5,28 +5,40 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def compare_without_order(a, b, file_name_a, file_name_b):
-    """Compare objects a and b, ignoring order if the types are dicts or sortable arrays
+def do_values_match(a, b, file_name_a, file_name_b):
+    """Compare a and b recursively, logging info about any mismatch found
     """
     aType = type(a)
     bType = type(b)
     if aType != bType:
-        log.warning("Mismatch: Objects have different types: %s vs %s", aType, bType)
+        log.warning("Mismatch: Values have different types: %s vs %s", aType, bType)
         return False
 
     if aType == dict:
         if len(a) != len(b):
-            log.warning("Mismatch: Dicts have different lengths (%s vs %s). a_keys=%s vs b_keys=%s", len(a), len(b), a.keys(), b.keys())
+            log.warning(
+                "Mismatch: Dicts have different lengths (%s vs %s). a_keys=%s vs b_keys=%s",
+                len(a),
+                len(b),
+                a.keys(),
+                b.keys(),
+            )
             return False
         for key in a:
             a_value = a[key]
             b_value = b.get(key)
 
             if b_value is None:
-                log.warning("Mismatch: Key %s present in %s but missing from %s dict with keys %s", key, file_name_a, file_name_b, b.keys())
+                log.warning(
+                    "Mismatch: Key %s present in %s but missing from %s dict with keys %s",
+                    key,
+                    file_name_a,
+                    file_name_b,
+                    b.keys(),
+                )
                 return False
 
-            if not compare_without_order(a_value, b_value, file_name_a, file_name_b):
+            if not do_values_match(a_value, b_value, file_name_a, file_name_b):
                 log.warning("Mismatch: Dict values at key %s do not match", key)
                 return False
 
@@ -34,49 +46,42 @@ def compare_without_order(a, b, file_name_a, file_name_b):
 
     if aType == list:
         if len(a) != len(b):
-            log.warning("Mismatch: Arrays have different lengths (%s vs %s)", len(a), len(b))
+            log.warning(
+                "Mismatch: Arrays have different lengths (%s vs %s)", len(a), len(b)
+            )
             return False
 
-        # Try sorting arrays but fall back to the original order if there's no
-        # builtin comparison fn
-        try:
-            sorted_a = sorted(a)
-            sorted_b = sorted(b)
-        except TypeError:
-            sorted_a = a
-            sorted_b = b
-
         for i in range(len(a)):
-            aListItem = sorted_a[i]
-            bListItem = sorted_b[i]
+            aListItem = a[i]
+            bListItem = b[i]
 
-            if not compare_without_order(aListItem, bListItem, file_name_a, file_name_b):
+            if not do_values_match(aListItem, bListItem, file_name_a, file_name_b):
                 log.warning("Mismatch: Array items at position %s do not match", i)
                 return False
 
         return True
 
-    do_objects_match = a == b
-    if not do_objects_match:
+    are_values_equal = a == b
+    if not are_values_equal:
         log.warning("Values %s and %s do not match", a, b)
-    return do_objects_match
+    return are_values_equal
 
 
-def compare_json_files_without_order(file_name_a, file_name_b):
+def do_json_files_match(file_name_a, file_name_b):
     with open(file_name_a) as fileA:
         file_a_data = json.load(fileA)
-    
+
     with open(file_name_b) as fileB:
         file_b_data = json.load(fileB)
 
-    return compare_without_order(file_a_data, file_b_data, file_name_a, file_name_b)
+    return do_values_match(file_a_data, file_b_data, file_name_a, file_name_b)
 
 
-def main(): 
-    if (len(sys.argv) != 3):
+def main():
+    if len(sys.argv) != 3:
         raise ValueError("Must provide 2 file names to compare")
-    
-    do_snapshots_match = compare_json_files_without_order(sys.argv[1], sys.argv[2])
+
+    do_snapshots_match = do_json_files_match(sys.argv[1], sys.argv[2])
 
     if not do_snapshots_match:
         sys.exit(1)

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -65,8 +65,6 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
     set +e # Dont exit right away if there is a diff in snapshots
     cd ..
     python $scripts_dir/compare_snapshots.py $integration_tests_dir/${TEST_SNAPSHOTS[i]} $integration_tests_dir/${CORRECT_SNAPSHOTS[i]}
-   
-    # diff ${TEST_SNAPSHOTS[i]} ${CORRECT_SNAPSHOTS[i]}
     return_code=$?
     set -e
     if [ $return_code -eq 0 ]; then

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -25,7 +25,7 @@ if [[ "$root_dir" =~ .*"serverless-plugin-datadog/scripts".* ]]; then
     exit 1
 fi
 
-integration_tests_dir="$repo_dir/integration_tests"
+integration_tests_dir="$root_dir/integration_tests"
 if [ "$UPDATE_SNAPSHOTS" = "true" ]; then
     echo "Overwriting snapshots in this execution"
 fi
@@ -63,7 +63,10 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
 
     echo "Performing diff of ${TEST_SNAPSHOTS[i]} against ${CORRECT_SNAPSHOTS[i]}"
     set +e # Dont exit right away if there is a diff in snapshots
-    diff ${TEST_SNAPSHOTS[i]} ${CORRECT_SNAPSHOTS[i]}
+    cd ..
+    python $scripts_dir/compare_snapshots.py $integration_tests_dir/${TEST_SNAPSHOTS[i]} $integration_tests_dir/${CORRECT_SNAPSHOTS[i]}
+   
+    # diff ${TEST_SNAPSHOTS[i]} ${CORRECT_SNAPSHOTS[i]}
     return_code=$?
     set -e
     if [ $return_code -eq 0 ]; then
@@ -73,6 +76,7 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
         echo "If you expected the ${TEST_SNAPSHOTS[i]} to be different generate new snapshots by running this command from a development branch on your local repository: 'UPDATE_SNAPSHOTS=true ./scripts/run_integration_tests.sh'"
         exit 1
     fi
+    cd $integration_tests_dir
     echo "===================================="
 done
 exit 0


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds a python script that is used by the integration test script to compare the snapshots instead of using diff

Example output when the snapshot was manually broken:
```
Performing diff of test_extension_snapshot.json against correct_extension_snapshot.json
Values AWS::Lambda::LayerVersion and AWS::Lambda::LayerVersion-BROKEN do not match
Mismatch: Dict values at key Type do not match
Mismatch: Dict values at key ProviderLevelLayerLambdaLayer do not match
Mismatch: Dict values at key Resources do not match
FAILURE: There were differences between the test_extension_snapshot.json and correct_extension_snapshot.json. Review the diff output above.
If you expected the test_extension_snapshot.json to be different generate new snapshots by running this command from a development branch on your local repository: 'UPDATE_SNAPSHOTS=true ./scripts/run_integration_tests.sh'
```

### Motivation

Integration tests were flaky because they were comparing json files with non-deterministic ordering of object keys, so equivalent snapshots were failing the tests due to ordering differences

### Testing Guidelines

Tested by running the integration tests locally

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
