### PR TITLE
fix: use service & env from custom configuration if defined when configure monitors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,8 +238,9 @@ module.exports = class ServerlessPlugin {
 
   private async afterDeploy() {
     const config = getConfig(this.serverless.service);
-    const service = this.serverless.service.getServiceName();
-    const env = this.serverless.getProvider("aws").getStage();
+    const custom = (this.serverless.service.custom ?? {}) as any;
+    const service = custom.datadog?.service ?? this.serverless.service.getServiceName();
+    const env = custom.datadog?.env ?? this.serverless.getProvider("aws").getStage();
 
     if (config.enabled === false) return;
     if (
@@ -270,7 +271,7 @@ module.exports = class ServerlessPlugin {
         }
       }
     }
-    return printOutputs(this.serverless, config.site, config.subdomain);
+    return printOutputs(this.serverless, config.site, config.subdomain, service, env);
   }
 
   private debugLogHandlers(handlers: FunctionInfo[]) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -33,10 +33,14 @@ export async function addOutputLinks(
   });
 }
 
-export async function printOutputs(serverless: Serverless, site: string, subdomain: string) {
+export async function printOutputs(
+  serverless: Serverless,
+  site: string,
+  subdomain: string,
+  service: string,
+  env: string,
+) {
   const stackName = serverless.getProvider("aws").naming.getStackName();
-  const service = serverless.service.getServiceName();
-  const env = serverless.getProvider("aws").getStage();
   const describeStackOutput = await serverless
     .getProvider("aws")
     .request(


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

use service & env from custom configuration if defined when configure monitors.

### Motivation

resolves #302

### Testing Guidelines

I used the plugin after the fix and checked that the monitor is using the service name & env from `custom.datadog` configuration.

I also verified that the plugin still works without defining service & env in `custom.datadog`.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
