### PR TITLE
docs: drop individual service-named configs and replace with current …

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ To further configure your plugin, use the following custom parameters in your `s
 | `monitors`                    | When defined, the Datadog plugin configures monitors for the deployed function. Requires setting `DATADOG_API_KEY` and `DATADOG_APP_KEY` in your environment. To learn how to define monitors, see [To Enable and Configure a Recommended Serverless Monitor](#to-enable-and-configure-a-recommended-serverless-monitor). |
 | `captureLambdaPayload`        | [Captures incoming and outgoing AWS Lambda payloads][17] in the Datadog APM spans for Lambda invocations. Defaults to `false`. |
 | `enableSourceCodeIntegration` | Enable [Datadog source code integration][18] for the function. Defaults to `true`. |
-| `subscribeToApiGatewayLogs`   | Enable automatic subscription of the Datadog Forwarder to API Gateway log groups. Requires setting `forwarderArn`. Defaults to `true`. |
-| `subscribeToHttpApiLogs`      | Enable automatic subscription of the Datadog Forwarder to HTTP API log groups. Requires setting `forwarderArn`. Defaults to `true`. |
-| `subscribeToWebsocketLogs`    | Enable automatic subscription of the Datadog Forwarder to WebSocket log groups. Requires setting `forwarderArn`. Defaults to `true`. |
+| `subscribeToAccessLogs`   | Enable automatic subscription of the Datadog Forwarder to API Gateway access log groups. Requires setting `forwarderArn`. Defaults to `true`. |
+| `subscribeToExecutionLogs`      | Enable automatic subscription of the Datadog Forwarder to HTTP API  and Websocket log groups. Requires setting `forwarderArn`. Defaults to `true`. |
 | `forwarderArn`                | The ARN of the Datadog Forwarder to be subscribed to the Lambda or API Gateway log groups. |
 | `addLayers`                   | Whether to install the Datadog Lambda library as a layer. Defaults to `true`. Set to `false` when you plan to package the Datadog Lambda library to your function's deployment package on your own so that you can install a specific version of the Datadog Lambda library ([Python][8] or [Node.js][9]). |
 | `addExtension`                | Whether to install the Datadog Lambda Extension as a layer. Defaults to `true`. When enabled, it's required to set the `apiKey` and `site`. |


### PR DESCRIPTION
We dropped these config options in https://github.com/DataDog/serverless-plugin-datadog/pull/176/files.

Closes https://github.com/DataDog/serverless-plugin-datadog/issues/308