### PR TITLE
Make Cloudformation output links optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `failOnError`                 | When set, this plugin throws an error if any custom Datadog monitors fail to create or update. This occurs after deploy, but will cause the result of `serverless deploy` to return a nonzero exit code (to fail user CI). Defaults to `false`. |
 | `integrationTesting`          | Set `true` when running integration tests. This bypasses the validation of the Forwarder ARN and the addition of Datadog Monitor output links. Defaults to `false`. |
 | `logLevel`                    | The log level, set to `DEBUG` for extended logging. |
+| `skipCloudformationOutputs`   | Set to `true` if you'd like to skip adding Datadog Cloudformation Outputs for your stack. Useful if you're running into the 200 output limit which can cause stack creation to fail. |
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `failOnError`                 | When set, this plugin throws an error if any custom Datadog monitors fail to create or update. This occurs after deploy, but will cause the result of `serverless deploy` to return a nonzero exit code (to fail user CI). Defaults to `false`. |
 | `integrationTesting`          | Set `true` when running integration tests. This bypasses the validation of the Forwarder ARN and the addition of Datadog Monitor output links. Defaults to `false`. |
 | `logLevel`                    | The log level, set to `DEBUG` for extended logging. |
-| `skipCloudformationOutputs`   | Set to `true` if you'd like to skip adding Datadog Cloudformation Outputs for your stack. Useful if you're running into the 200 output limit which can cause stack creation to fail. |
+| `skipCloudformationOutputs`   | Set to `true` if you want to skip adding Datadog Cloudformation Outputs for your stack. This is useful if you are running into the 200 output limit which can cause the stack creation to fail. |
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -434,6 +434,7 @@ describe("setEnvConfiguration", () => {
         enableSourceCodeIntegration: true,
         captureLambdaPayload: false,
         failOnError: false,
+        skipCloudformationOutputs: false,
       },
       handlers,
     );
@@ -572,6 +573,7 @@ describe("setEnvConfiguration", () => {
         exclude: [],
         enableSourceCodeIntegration: true,
         failOnError: false,
+        skipCloudformationOutputs: false,
       },
       handlers,
     );
@@ -654,6 +656,7 @@ describe("setEnvConfiguration", () => {
         exclude: [],
         enableSourceCodeIntegration: true,
         failOnError: false,
+        skipCloudformationOutputs: false,
       },
       handlers,
     );
@@ -709,6 +712,7 @@ describe("setEnvConfiguration", () => {
         exclude: ["dd-excluded-function"],
         enableSourceCodeIntegration: true,
         failOnError: false,
+        skipCloudformationOutputs: false,
       },
       handlers,
     );
@@ -764,6 +768,7 @@ describe("setEnvConfiguration", () => {
         exclude: ["dd-excluded-function"],
         enableSourceCodeIntegration: true,
         failOnError: false,
+        skipCloudformationOutputs: false,
       },
       handlers,
     );
@@ -818,6 +823,7 @@ describe("setEnvConfiguration", () => {
         exclude: ["dd-excluded-function"],
         enableSourceCodeIntegration: true,
         failOnError: false,
+        skipCloudformationOutputs: false,
       },
       handlers,
     );
@@ -875,6 +881,7 @@ describe("setEnvConfiguration", () => {
           exclude: ["dd-excluded-function"],
           enableSourceCodeIntegration: true,
           failOnError: false,
+          skipCloudformationOutputs: false,
         },
         handlers,
       );

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -189,6 +189,7 @@ describe("getConfig", () => {
       subscribeToExecutionLogs: false,
       enableSourceCodeIntegration: true,
       failOnError: false,
+      skipCloudformationOutputs: false,
     });
   });
 
@@ -222,6 +223,7 @@ describe("getConfig", () => {
       subscribeToExecutionLogs: false,
       enableSourceCodeIntegration: true,
       failOnError: false,
+      skipCloudformationOutputs: false,
     });
   });
 
@@ -256,6 +258,7 @@ describe("getConfig", () => {
       customHandler: "/src/custom-handler.handler",
       enableSourceCodeIntegration: true,
       failOnError: false,
+      skipCloudformationOutputs: false,
     });
   });
 });
@@ -290,6 +293,7 @@ it("disable source code integration", () => {
     subscribeToExecutionLogs: false,
     enableSourceCodeIntegration: false,
     failOnError: false,
+    skipCloudformationOutputs: false,
   });
 });
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -74,6 +74,9 @@ export interface Configuration {
   // API Gateway Execution logging - handles rest and websocket. Http not supported as of Sept.21
   subscribeToExecutionLogs: boolean;
 
+  // Skip populating the Cloudformation Outputs
+  skipCloudformationOutputs: boolean;
+
   // When set, this plugin will configure the specified handler for the functions
   customHandler?: string;
 }
@@ -119,6 +122,7 @@ export const defaultConfiguration: Configuration = {
   enableDDLogs: true,
   captureLambdaPayload: false,
   failOnError: false,
+  skipCloudformationOutputs: false,
 };
 
 export function setEnvConfiguration(config: Configuration, handlers: FunctionInfo[]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,10 +230,10 @@ module.exports = class ServerlessPlugin {
     }
 
     redirectHandlers(handlers, config.addLayers, config.customHandler);
-    if (config.integrationTesting === false) {
+    if (config.integrationTesting === false && config.skipCloudformationOutputs === false) {
       await addOutputLinks(this.serverless, config.site, config.subdomain, handlers);
     } else {
-      this.serverless.cli.log("Skipped adding output links because 'integrationTesting' is set true");
+      this.serverless.cli.log("Skipped adding output links");
     }
   }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR fixes an issue where it's possible to run into the 200 output limit in CloudFormation because our Serverless Plugin creates an output for each endpoint in Serverless. The solution is to add a configuration option that allows the user to skip adding these outputs.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Tested manually, see below images:

**Before**

![image](https://user-images.githubusercontent.com/2540856/200631510-73a7cc5e-9418-4172-aa01-b27f188e80ab.png)

**After**

![image](https://user-images.githubusercontent.com/2540856/200631573-e4fb99c8-3496-4871-905e-7c0e56987bc9.png)

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
