### PR TITLE
Clarify CLI Github integration error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -207,8 +207,14 @@ module.exports = class ServerlessPlugin {
 
     if (config.enableSourceCodeIntegration) {
       if ((process.env.DATADOG_API_KEY ?? config.apiKey) === undefined) {
+        let keyError;
+        if (config.apiKeySecretArn) {
+          keyError = "encrypted credentials through KMS/Secrets Manager is not supported for this integration";
+        } else {
+          keyError = "Datadog credentials were not found";
+        }
         this.serverless.cli.log(
-          "Skipping installing GitHub integration because Datadog credentials were not found. Please set either DATADOG_API_KEY in your environment, or set the apiKey parameter in Serverless.",
+          `Skipping installing GitHub integration because ${keyError}. Please set either DATADOG_API_KEY in your environment, or set the apiKey parameter in Serverless.`,
         );
       } else {
         const simpleGit = await newSimpleGit();


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Clarifies lack of support for using a API key secret ARN with github integration in a CLI error message

### Motivation

<!--- What inspired you to submit this pull request? --->
https://github.com/DataDog/serverless-plugin-datadog/issues/305

### Testing Guidelines

<!--- How did you test this pull request? --->
Wrote and ran unit tests, tested manually by deploying a testing app

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
