### PR TITLE
fix: bumped layer version to v33

### DIFF
--- a/src/layers-gov.json
+++ b/src/layers-gov.json
@@ -10,8 +10,8 @@
       "python3.8-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet:6"
     },
     "us-gov-east-1": {
@@ -24,8 +24,8 @@
       "python3.8-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet:6"
     }
   }

--- a/src/layers.json
+++ b/src/layers.json
@@ -10,8 +10,8 @@
       "python3.8-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:6"
     },
@@ -25,8 +25,8 @@
       "python3.8-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:6"
     },
@@ -40,8 +40,8 @@
       "python3.8-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:6"
     },
@@ -55,8 +55,8 @@
       "python3.8-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:6"
     },
@@ -70,8 +70,8 @@
       "python3.8-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:6"
     },
@@ -85,8 +85,8 @@
       "python3.8-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:6"
     },
@@ -100,8 +100,8 @@
       "python3.8-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:6"
     },
@@ -115,8 +115,8 @@
       "python3.8-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:6"
     },
@@ -130,8 +130,8 @@
       "python3.8-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:6"
     },
@@ -145,8 +145,8 @@
       "python3.8-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:6"
     },
@@ -160,14 +160,14 @@
       "python3.8-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:6"
     },
     "me-central-1": {
-      "extension": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension-ARM:32"
+      "extension": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension-ARM:33"
     },
     "sa-east-1": {
       "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:84",
@@ -179,8 +179,8 @@
       "python3.8-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:6"
     },
@@ -194,8 +194,8 @@
       "python3.8-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:6"
     },
@@ -209,8 +209,8 @@
       "python3.8-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:6"
     },
@@ -224,8 +224,8 @@
       "python3.8-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:6"
     },
@@ -239,8 +239,8 @@
       "python3.8-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:6"
     },
@@ -253,8 +253,8 @@
       "python3.8-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-dotnet:6"
     },
     "eu-central-1": {
@@ -267,8 +267,8 @@
       "python3.8-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:6"
     },
@@ -282,8 +282,8 @@
       "python3.8-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:6"
     },
@@ -297,8 +297,8 @@
       "python3.8-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:6"
     },
@@ -312,8 +312,8 @@
       "python3.8-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:6"
     },
@@ -327,8 +327,8 @@
       "python3.8-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38-ARM:63",
       "python3.9": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python39:63",
       "python3.9-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python39-ARM:63",
-      "extension": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:32",
-      "extension-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:32",
+      "extension": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:33",
+      "extension-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:33",
       "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet:6",
       "java": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-java:6"
     }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR bumps the lambda layer version to v33. 
This version now implements Lambda telemetry. 

### Motivation

The Lambda Telemetry API was released.
The update to the DD extension provides more detailed metrics about functions. 

### Testing Guidelines

Deployed on my personal functions and ran unit tests.

### Additional Notes

n/a

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
