### PR TITLE
Add support for .NET ARM layer

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -629,7 +629,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:85",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:86",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -669,7 +669,7 @@
           {
             "Ref": "ProviderLevelLayerLambdaLayer"
           },
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:85",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:86",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
         ]
       },

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -840,7 +840,7 @@
           ]
         },
         "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:85"
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:86"
         ]
       },
       "DependsOn": [

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -498,6 +498,37 @@ describe("applyLambdaLibraryLayers", () => {
     });
   });
 
+  it("adds correct lambda layer given architecture in provider level for .NET", () => {
+    const handler = {
+      handler: { runtime: "dotnet6" },
+      type: RuntimeType.DOTNET,
+      runtime: "dotnet6",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: {
+        "us-east-1": {
+          "dd-trace-dotnet": "dd-trace-dotnet:6",
+          "dd-trace-dotnet-ARM": "dd-trace-dotnet-ARM:6",
+          extension: "extension:11",
+          "extension-arm": "extension-arm:11",
+        },
+      },
+    };
+    const mockService = createMockService(
+      "us-east-1",
+      {
+        ".NET-function": { handler: "myfile.handler", runtime: "dotnet6" },
+      },
+      "arm64",
+    );
+    applyLambdaLibraryLayers(mockService, [handler], layers);
+    applyExtensionLayer(mockService, [handler], layers);
+    expect(handler.handler).toEqual({
+      runtime: "dotnet6",
+      layers: ["dd-trace-dotnet-ARM:6", "extension-arm:11"],
+    });
+  });
+
   it("uses default runtime layer if architecture not available for specified runtime", () => {
     const handler = {
       handler: { runtime: "python3.7", architecture: "arm64" },

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -68,6 +68,7 @@ export const armRuntimeKeys: { [key: string]: string } = {
   "python3.8": "python3.8-arm",
   "python3.9": "python3.9-arm",
   extension: "extension-arm",
+  dotnet6: "dd-trace-dotnet-ARM",
 };
 
 const dotnetTraceLayerKey: string = "dotnet";


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
- Adds the `dd-trace-dotnet-ARM` layer to ARM layer lookup.
- Adds a test for .NET
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Previously this layer was not being applied to ARM functions.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

New unit test
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
