### PR TITLE
[SLS-2707] Fix Missing API and APP Keys Error Message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -478,7 +478,7 @@ function validateConfiguration(config: Configuration) {
     if (
       (process.env.DATADOG_API_KEY === undefined || process.env.DATADOG_APP_KEY === undefined) &&
       // Support deprecated monitorsApiKey and monitorsAppKey
-      (config.apiKey === undefined || config.appKey === undefined)
+      (config.apiKey === undefined || config.appKey === undefined) && config.integrationTesting === false
     ) {
       throw new Error(
         "When `monitors` is enabled, `DATADOG_API_KEY` and `DATADOG_APP_KEY` environment variables must be set.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,7 +478,8 @@ function validateConfiguration(config: Configuration) {
     if (
       (process.env.DATADOG_API_KEY === undefined || process.env.DATADOG_APP_KEY === undefined) &&
       // Support deprecated monitorsApiKey and monitorsAppKey
-      (config.apiKey === undefined || config.appKey === undefined) && config.integrationTesting === false
+      (config.apiKey === undefined || config.appKey === undefined) &&
+      config.integrationTesting === false
     ) {
       throw new Error(
         "When `monitors` is enabled, `DATADOG_API_KEY` and `DATADOG_APP_KEY` environment variables must be set.",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Changes the "When `monitors` is enabled, `DATADOG_API_KEY` and `DATADOG_APP_KEY` environment variables must be set." error message to only throw when `integrationTesting` is set to false. 
<!--- A brief description of the change being made with this pull request. --->

### Motivation
https://datadoghq.atlassian.net/browse/SLS-2707
https://github.com/DataDog/serverless-plugin-datadog/issues/310
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
