### PR TITLE
Add DD_INSTRUMENTATION_SOURCE on Step Function Log Groups

### DIFF
--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -410,7 +410,13 @@
     "stepFunctionNoLoggingConfigLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/stepFunctionNoLoggingConfig-Logs-dev"
+        "LogGroupName": "/aws/vendedlogs/states/stepFunctionNoLoggingConfig-Logs-dev",
+        "Tags": [
+          {
+            "Key": "DD_INSTRUMENTATION_SOURCE",
+            "Value": "serverless-plugin-datadog"
+          }
+        ]
       }
     },
     "stepFunctionNoLoggingConfigLogGroupSubscription": {

--- a/src/forwarder.spec.ts
+++ b/src/forwarder.spec.ts
@@ -1165,6 +1165,12 @@ describe("addStepFunctionLogGroup", () => {
         "testStepFunctionLogGroup": Object {
           "Properties": Object {
             "LogGroupName": "/aws/vendedlogs/states/testStepFunction-Logs-dev",
+            "Tags": Array [
+              Object {
+                "Key": "DD_INSTRUMENTATION_SOURCE",
+                "Value": "serverless-plugin-datadog",
+              },
+            ],
           },
           "Type": "AWS::Logs::LogGroup",
         },
@@ -1201,6 +1207,12 @@ describe("addStepFunctionLogGroup", () => {
         "testStepFunctionLogGroup": Object {
           "Properties": Object {
             "LogGroupName": "/aws/vendedlogs/states/test-StepFunction-Logs-dev",
+            "Tags": Array [
+              Object {
+                "Key": "DD_INSTRUMENTATION_SOURCE",
+                "Value": "serverless-plugin-datadog",
+              },
+            ],
           },
           "Type": "AWS::Logs::LogGroup",
         },

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -126,6 +126,7 @@ export async function addStepFunctionLogGroup(aws: Aws, resources: any, stepFunc
     Type: logGroupKey,
     Properties: {
       LogGroupName: logGroupName,
+      Tags: [{ Key: "DD_INSTRUMENTATION_SOURCE", Value: "serverless-plugin-datadog" }],
     },
   };
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

When a Step Function log group is created by the Datadog Serverless Plugin, add the `DD_INSTRUMENTATION_SOURCE: serverless-plugin-datadog` as a tag on the log group.

### Motivation

Would like to track usage of Step Function Log Group subscription from the Datadog Serverless Plugin. Will also implement the same tag with a different value in the [datadog-ci](https://github.com/DataDog/datadog-ci) tool.

https://datadoghq.atlassian.net/browse/SLS-3186

### Testing Guidelines

* Updated unit test and integration test for asserting that created log group has the expected tag
* Deployed Step Function with local build and confirmed that log group has the expected tag

### Additional Notes

The changes in this PR only cover 1 of 3 scenarios for Step Function Log Groups:

1. Step Function log group created by plugin -> tagged with `DD_INSTRUMENTATION_SOURCE`
2. Step Function log group created outside of `serverless.yml` -> unable to tag since the log group is not a part of the CloudFormation stack generated by `serverless.yml`
3. Step Function log group created in `resources` of `serverless.yml` -> tagging could be done but would require more complex logic. We could hook into a later lifecycle event, likely after `aws:package:finalize:mergeCustomProviderResources`, and tag all Step Function log groups in the complied CloudFormation template.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
