### PR TITLE
Revert "Add DD_INSTRUMENTATION_SOURCE on Step Function Log Groups"

### DIFF
--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -410,13 +410,7 @@
     "stepFunctionNoLoggingConfigLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
-        "LogGroupName": "/aws/vendedlogs/states/stepFunctionNoLoggingConfig-Logs-dev",
-        "Tags": [
-          {
-            "Key": "DD_INSTRUMENTATION_SOURCE",
-            "Value": "serverless-plugin-datadog"
-          }
-        ]
+        "LogGroupName": "/aws/vendedlogs/states/stepFunctionNoLoggingConfig-Logs-dev"
       }
     },
     "stepFunctionNoLoggingConfigLogGroupSubscription": {

--- a/src/forwarder.spec.ts
+++ b/src/forwarder.spec.ts
@@ -1165,12 +1165,6 @@ describe("addStepFunctionLogGroup", () => {
         "testStepFunctionLogGroup": Object {
           "Properties": Object {
             "LogGroupName": "/aws/vendedlogs/states/testStepFunction-Logs-dev",
-            "Tags": Array [
-              Object {
-                "Key": "DD_INSTRUMENTATION_SOURCE",
-                "Value": "serverless-plugin-datadog",
-              },
-            ],
           },
           "Type": "AWS::Logs::LogGroup",
         },
@@ -1207,12 +1201,6 @@ describe("addStepFunctionLogGroup", () => {
         "testStepFunctionLogGroup": Object {
           "Properties": Object {
             "LogGroupName": "/aws/vendedlogs/states/test-StepFunction-Logs-dev",
-            "Tags": Array [
-              Object {
-                "Key": "DD_INSTRUMENTATION_SOURCE",
-                "Value": "serverless-plugin-datadog",
-              },
-            ],
           },
           "Type": "AWS::Logs::LogGroup",
         },

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -126,7 +126,6 @@ export async function addStepFunctionLogGroup(aws: Aws, resources: any, stepFunc
     Type: logGroupKey,
     Properties: {
       LogGroupName: logGroupName,
-      Tags: [{ Key: "DD_INSTRUMENTATION_SOURCE", Value: "serverless-plugin-datadog" }],
     },
   };
 


### PR DESCRIPTION
Reverts DataDog/serverless-plugin-datadog#364

Instead of creating a new tag, `DD_INSTRUMENTATION_SOURCE`, for Step Function log groups, we plan on using the Lambda function tags (`dd_sls_plugin`, `dd_sls_macro`, `dd_cdk_construct`, `dd_sls_ci` on Step Functions and potentially Step Function log groups as well.