### PR TITLE
Move prettier to runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "jest": "^26.6.3",
     "jest-environment-node": "^26.6.2",
     "mock-fs": "4.13.0",
-    "prettier": "^2.2.1",
     "ts-jest": "^26.4.4",
     "tslint": "^6.1.3",
     "typescript": "^4.1.3"
@@ -58,7 +57,8 @@
   "dependencies": {
     "@datadog/datadog-ci": "^2.4.0",
     "node-fetch": "^2.6.1",
-    "simple-git": "^3.16.0"
+    "simple-git": "^3.16.0",
+    "prettier": "^2.2.1"
   },
   "peerDependencies": {
     "serverless": "3.x || 2.x || 1.x"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Makes prettier a runtime dependency

### Motivation

Prettier is required for runtime but only listed as a devDependency.
Issue: https://github.com/DataDog/serverless-plugin-datadog/issues/369

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
