### PR TITLE
feat: Add support for python 3.10

### DIFF
--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-java")
+LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-java")
 JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "python3.6" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "extension" "extension-arm" "dotnet" "java")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -50,6 +50,7 @@ describe("findHandlers", () => {
       "python37-function": { handler: "myfile.handler", runtime: "python3.7" },
       "python38-function": { handler: "myfile.handler", runtime: "python3.8" },
       "python39-function": { handler: "myfile.handler", runtime: "python3.9" },
+      "python310-function": { handler: "myfile.handler", runtime: "python3.10" },
     });
 
     const result = findHandlers(mockService, []);
@@ -107,6 +108,12 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "python3.9" },
         type: RuntimeType.PYTHON,
         runtime: "python3.9",
+      },
+      {
+        name: "python310-function",
+        handler: { handler: "myfile.handler", runtime: "python3.10" },
+        type: RuntimeType.PYTHON,
+        runtime: "python3.10",
       },
     ]);
   });

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -53,6 +53,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.7": RuntimeType.PYTHON,
   "python3.8": RuntimeType.PYTHON,
   "python3.9": RuntimeType.PYTHON,
+  "python3.10": RuntimeType.PYTHON,
   "dotnetcore3.1": RuntimeType.DOTNET,
   dotnet6: RuntimeType.DOTNET,
   java11: RuntimeType.JAVA,
@@ -67,6 +68,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
 export const armRuntimeKeys: { [key: string]: string } = {
   "python3.8": "python3.8-arm",
   "python3.9": "python3.9-arm",
+  "python3.10": "python3.10-arm",
   extension: "extension-arm",
   dotnet6: "dd-trace-dotnet-ARM",
 };


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Python 3.10 is right around the corner, as confirmed by AWS in this [issue](https://github.com/aws/aws-lambda-base-images/issues/31#issuecomment-1448638312). This PR is in place so when the launch occurs, we'll be ready

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

I verified this locally, which was a bit tricky:
1. Manually update `layers.json` to add `python3.10` for us-east-1, specifying the version we just published (71)
2. Linking this library with a test application
3. running `sls package` with a python3.10 app
4. Note, you need to ignore the serverless warning, as [serverless does not yet support 3.10](https://github.com/serverless/serverless/issues/11921)
5. CF JSON looks good:
<img width="2194" alt="image" src="https://user-images.githubusercontent.com/1598537/232790869-80e59bf4-afd0-4ddf-8fc3-941073bff9cd.png">
6. Logs/Metrics/Traces are received

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
