### PR TITLE
fix: fix generate layers script

### DIFF
--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -14,7 +14,7 @@
 set -e
 
 LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "python3.6" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "extension" "extension-arm" "dotnet" "java")
+JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "python3.6" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "extension" "extension-arm" "dotnet" "java")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 FILE_NAME="src/layers.json"

--- a/src/layers.json
+++ b/src/layers.json
@@ -11,11 +11,12 @@
       "python3.8-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:9"
     },
     "ap-south-1": {
       "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:88",
@@ -28,11 +29,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:9"
     },
     "eu-north-1": {
       "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:88",
@@ -45,11 +47,12 @@
       "python3.8-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:9"
     },
     "eu-west-3": {
       "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:88",
@@ -62,11 +65,12 @@
       "python3.8-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:9"
     },
     "eu-south-1": {
       "nodejs12.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node12-x:88",
@@ -79,11 +83,12 @@
       "python3.8-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:9"
     },
     "eu-west-2": {
       "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:88",
@@ -96,11 +101,12 @@
       "python3.8-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:9"
     },
     "eu-west-1": {
       "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:88",
@@ -113,11 +119,12 @@
       "python3.8-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:9"
     },
     "ap-northeast-3": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Node12-x:88",
@@ -130,11 +137,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:9"
     },
     "ap-northeast-2": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:88",
@@ -147,11 +155,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:9"
     },
     "me-south-1": {
       "nodejs12.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node12-x:88",
@@ -164,11 +173,12 @@
       "python3.8-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:9"
     },
     "ap-northeast-1": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:88",
@@ -181,11 +191,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:9"
     },
     "me-central-1": {
       "nodejs12.x": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Node12-x:88",
@@ -197,11 +208,12 @@
       "python3.8-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-java:9"
     },
     "ca-central-1": {
       "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:88",
@@ -214,11 +226,12 @@
       "python3.8-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:9"
     },
     "sa-east-1": {
       "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:88",
@@ -231,11 +244,12 @@
       "python3.8-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:9"
     },
     "ap-east-1": {
       "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:88",
@@ -248,11 +262,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:9"
     },
     "ap-southeast-1": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:88",
@@ -265,11 +280,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:9"
     },
     "ap-southeast-2": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:88",
@@ -282,11 +298,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:9"
     },
     "eu-central-1": {
       "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:88",
@@ -299,11 +316,12 @@
       "python3.8-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:9"
     },
     "ap-southeast-3": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Node12-x:88",
@@ -315,11 +333,12 @@
       "python3.8-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-java:9"
     },
     "us-east-1": {
       "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:88",
@@ -332,11 +351,12 @@
       "python3.8-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:9"
     },
     "us-east-2": {
       "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:88",
@@ -349,11 +369,12 @@
       "python3.8-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:9"
     },
     "us-west-1": {
       "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:88",
@@ -366,11 +387,12 @@
       "python3.8-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:9"
     },
     "us-west-2": {
       "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:88",
@@ -383,11 +405,12 @@
       "python3.8-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python38-ARM:71",
       "python3.9": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python39:71",
       "python3.9-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python39-ARM:71",
-      "extension": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python310:71",
-      "extension-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python310-ARM:71",
-      "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:41",
-      "java": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:41",
-      "": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-java:9"
+      "python3.10": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python310:71",
+      "python3.10-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python310-ARM:71",
+      "extension": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:41",
+      "extension-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:41",
+      "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet:7",
+      "java": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-java:9"
     }
   }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Supporting 3.10 introduced a regression which caused the layers.json file to be off-by-one

### Motivation

This script only runs on release, I manually ran it and realized the layers were incorrect. This change fixes it, as shown by the new layers.json

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
