### PR TITLE
add api gateway subscription with addExtension: false

### DIFF
--- a/src/forwarder.spec.ts
+++ b/src/forwarder.spec.ts
@@ -271,6 +271,16 @@ describe("addCloudWatchForwarderSubscriptions", () => {
           },
           "Type": "AWS::Logs::LogGroup",
         },
+        "NonLambdaGroupSubscription": Object {
+          "Properties": Object {
+            "DestinationArn": "my-func",
+            "FilterPattern": "",
+            "LogGroupName": Object {
+              "Ref": "NonLambdaGroup",
+            },
+          },
+          "Type": "AWS::Logs::SubscriptionFilter",
+        },
         "SecondLogGroup": Object {
           "Properties": Object {
             "LogGroupName": "/aws/lambda/second",
@@ -435,6 +445,16 @@ describe("addCloudWatchForwarderSubscriptions", () => {
           },
           "Type": "AWS::Logs::LogGroup",
         },
+        "ApiGatewayGroupSubscription": Object {
+          "Properties": Object {
+            "DestinationArn": "my-func",
+            "FilterPattern": "",
+            "LogGroupName": Object {
+              "Ref": "ApiGatewayGroup",
+            },
+          },
+          "Type": "AWS::Logs::SubscriptionFilter",
+        },
         "FirstLogGroup": Object {
           "Properties": Object {
             "LogGroupName": "/aws/lambda/first",
@@ -457,11 +477,31 @@ describe("addCloudWatchForwarderSubscriptions", () => {
           },
           "Type": "AWS::Logs::LogGroup",
         },
+        "HttpApiGroupSubscription": Object {
+          "Properties": Object {
+            "DestinationArn": "my-func",
+            "FilterPattern": "",
+            "LogGroupName": Object {
+              "Ref": "HttpApiGroup",
+            },
+          },
+          "Type": "AWS::Logs::SubscriptionFilter",
+        },
         "NonLambdaGroup": Object {
           "Properties": Object {
             "LogGroupName": "/aws/apigateway/second-group",
           },
           "Type": "AWS::Logs::LogGroup",
+        },
+        "NonLambdaGroupSubscription": Object {
+          "Properties": Object {
+            "DestinationArn": "my-func",
+            "FilterPattern": "",
+            "LogGroupName": Object {
+              "Ref": "NonLambdaGroup",
+            },
+          },
+          "Type": "AWS::Logs::SubscriptionFilter",
         },
         "SecondLogGroup": Object {
           "Properties": Object {

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -327,7 +327,7 @@ function shouldSubscribe(
       validateWebsocketSubscription(resource, forwarderConfigs.SubToAccessLogGroups, extendedProvider)
     )
   ) {
-    return false;
+    return true;
   }
 
   // If the log group does not belong to our list of handlers, we don't want to subscribe to it


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

This adds Log Group subscriptions for API Gateway when `addExtension` is set to `false`. This looks like it was the intention of the code as noted in the comment above the change

### Motivation

<!--- What inspired you to submit this pull request? --->

Bug fix

### Testing Guidelines

<!--- How did you test this pull request? --->

* Add API Gateway with Custom Logging setup
* Add plugin config `forwarderArn` set to a valid ARN and `addExtension` set to `false`
* This should add a subscription to the API Gateway Log Group (currently does not)

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
