### PR TITLE
Downgrade java layer version from v9 to v8.

### DIFF
--- a/src/layers.json
+++ b/src/layers.json
@@ -16,7 +16,7 @@
       "extension": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:8"
     },
     "ap-south-1": {
       "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:88",
@@ -34,7 +34,7 @@
       "extension": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:8"
     },
     "eu-north-1": {
       "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:88",
@@ -52,7 +52,7 @@
       "extension": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:8"
     },
     "eu-west-3": {
       "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:88",
@@ -70,7 +70,7 @@
       "extension": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:8"
     },
     "eu-south-1": {
       "nodejs12.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node12-x:88",
@@ -88,7 +88,7 @@
       "extension": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:8"
     },
     "eu-west-2": {
       "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:88",
@@ -106,7 +106,7 @@
       "extension": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:8"
     },
     "eu-west-1": {
       "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:88",
@@ -124,7 +124,7 @@
       "extension": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:8"
     },
     "ap-northeast-3": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Node12-x:88",
@@ -142,7 +142,7 @@
       "extension": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:8"
     },
     "ap-northeast-2": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:88",
@@ -160,7 +160,7 @@
       "extension": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:8"
     },
     "me-south-1": {
       "nodejs12.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node12-x:88",
@@ -178,7 +178,7 @@
       "extension": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:8"
     },
     "ap-northeast-1": {
       "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:88",
@@ -196,7 +196,7 @@
       "extension": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:8"
     },
     "me-central-1": {
       "nodejs12.x": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Node12-x:88",
@@ -213,7 +213,7 @@
       "extension": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-java:8"
     },
     "ca-central-1": {
       "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:88",
@@ -231,7 +231,7 @@
       "extension": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:8"
     },
     "sa-east-1": {
       "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:88",
@@ -249,7 +249,7 @@
       "extension": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:8"
     },
     "ap-east-1": {
       "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:88",
@@ -267,7 +267,7 @@
       "extension": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:8"
     },
     "ap-southeast-1": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:88",
@@ -285,7 +285,7 @@
       "extension": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:8"
     },
     "ap-southeast-2": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:88",
@@ -303,7 +303,7 @@
       "extension": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:8"
     },
     "eu-central-1": {
       "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:88",
@@ -321,7 +321,7 @@
       "extension": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:8"
     },
     "ap-southeast-3": {
       "nodejs12.x": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Node12-x:88",
@@ -338,7 +338,7 @@
       "extension": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-java:8"
     },
     "us-east-1": {
       "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:88",
@@ -356,7 +356,7 @@
       "extension": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:8"
     },
     "us-east-2": {
       "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:88",
@@ -374,7 +374,7 @@
       "extension": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:8"
     },
     "us-west-1": {
       "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:88",
@@ -392,7 +392,7 @@
       "extension": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:8"
     },
     "us-west-2": {
       "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:88",
@@ -410,7 +410,7 @@
       "extension": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:41",
       "extension-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:41",
       "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet:7",
-      "java": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-java:9"
+      "java": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-java:8"
     }
   }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Downgrade the version of the java tracer from v9 to v8.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

https://github.com/DataDog/dd-trace-java/pull/4844