### PR TITLE
[SLS-3290] Support using DD Lambda layers published from one's own AWS account

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -102,6 +102,9 @@ export interface Configuration {
   // When the remaining time in a Lambda invocation is less than `apmFlushDeadline`, the tracer will
   // attempt to submit the current active spans and all finished spans.
   apmFlushDeadline?: string | number;
+
+  // Whether the plugin should look for Datadog Lambda layers in the local AWS account to use
+  useLocalAccountLayers?: boolean;
 }
 const webpackPluginName = "serverless-webpack";
 const apiKeyEnvVar = "DD_API_KEY";
@@ -122,6 +125,7 @@ const ddProfilingEnabledEnvVar = "DD_PROFILING_ENABLED";
 const ddEncodeAuthorizerContextEnvVar = "DD_ENCODE_AUTHORIZER_CONTEXT";
 const ddDecodeAuthorizerContextEnvVar = "DD_DECODE_AUTHORIZER_CONTEXT";
 const ddApmFlushDeadlineMillisecondsEnvVar = "DD_APM_FLUSH_DEADLINE_MILLISECONDS";
+const ddUseLocalAccountLayers = "DD_USE_LOCAL_ACCOUNT_LAYERS";
 
 export const ddServiceEnvVar = "DD_SERVICE";
 export const ddEnvEnvVar = "DD_ENV";
@@ -235,6 +239,9 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
     }
     if (config.apmFlushDeadline !== undefined && environment[ddApmFlushDeadlineMillisecondsEnvVar] === undefined) {
       environment[ddApmFlushDeadlineMillisecondsEnvVar] = config.apmFlushDeadline;
+    }
+    if (config.useLocalAccountLayers !== undefined && environment[ddUseLocalAccountLayers] === undefined) {
+      environment[ddUseLocalAccountLayers] = config.useLocalAccountLayers;
     }
     if (type === RuntimeType.DOTNET || type === RuntimeType.JAVA) {
       if (environment[AWS_LAMBDA_EXEC_WRAPPER_VAR] === undefined) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -103,8 +103,8 @@ export interface Configuration {
   // attempt to submit the current active spans and all finished spans.
   apmFlushDeadline?: string | number;
 
-  // Whether the plugin should look for Datadog Lambda layers in the local AWS account to use
-  useLocalAccountLayers?: boolean;
+  // Whether the plugin should look for Datadog Lambda layers in the given AWS account to use
+  useLayersFromAccount?: string;
 }
 const webpackPluginName = "serverless-webpack";
 const apiKeyEnvVar = "DD_API_KEY";
@@ -125,7 +125,7 @@ const ddProfilingEnabledEnvVar = "DD_PROFILING_ENABLED";
 const ddEncodeAuthorizerContextEnvVar = "DD_ENCODE_AUTHORIZER_CONTEXT";
 const ddDecodeAuthorizerContextEnvVar = "DD_DECODE_AUTHORIZER_CONTEXT";
 const ddApmFlushDeadlineMillisecondsEnvVar = "DD_APM_FLUSH_DEADLINE_MILLISECONDS";
-const ddUseLocalAccountLayers = "DD_USE_LOCAL_ACCOUNT_LAYERS";
+const ddUseLayersFromAccount = "DD_USE_LAYERS_FROM_ACCOUNT";
 
 export const ddServiceEnvVar = "DD_SERVICE";
 export const ddEnvEnvVar = "DD_ENV";
@@ -240,8 +240,8 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
     if (config.apmFlushDeadline !== undefined && environment[ddApmFlushDeadlineMillisecondsEnvVar] === undefined) {
       environment[ddApmFlushDeadlineMillisecondsEnvVar] = config.apmFlushDeadline;
     }
-    if (config.useLocalAccountLayers !== undefined && environment[ddUseLocalAccountLayers] === undefined) {
-      environment[ddUseLocalAccountLayers] = config.useLocalAccountLayers;
+    if (config.useLayersFromAccount !== undefined && environment[ddUseLayersFromAccount] === undefined) {
+      environment[ddUseLayersFromAccount] = config.useLayersFromAccount;
     }
     if (type === RuntimeType.DOTNET || type === RuntimeType.JAVA) {
       if (environment[AWS_LAMBDA_EXEC_WRAPPER_VAR] === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,9 @@ module.exports = class ServerlessPlugin {
     setEnvConfiguration(config, handlers);
 
     const allLayers = { regions: { ...layers.regions, ...govLayers.regions } };
-    const accountId = config.useLocalAccountLayers ? await this.serverless.getProvider("aws").getAccountId() : undefined;
+    const accountId = config.useLocalAccountLayers
+      ? await this.serverless.getProvider("aws").getAccountId()
+      : undefined;
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Library Layers to functions");
       this.debugLogHandlers(handlers);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,8 +34,7 @@ import {
 import { newSimpleGit } from "./git";
 import {
   applyExtensionLayer,
-  applyDotnetTracingLayer,
-  applyJavaTracingLayer,
+  applyTracingLayer,
   applyLambdaLibraryLayers,
   findHandlers,
   FunctionInfo,
@@ -122,10 +121,11 @@ module.exports = class ServerlessPlugin {
     setEnvConfiguration(config, handlers);
 
     const allLayers = { regions: { ...layers.regions, ...govLayers.regions } };
+    const accountId = config.useLocalAccountLayers ? await this.serverless.getProvider("aws").getAccountId() : undefined;
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Library Layers to functions");
       this.debugLogHandlers(handlers);
-      applyLambdaLibraryLayers(this.serverless.service, handlers, allLayers);
+      applyLambdaLibraryLayers(this.serverless.service, handlers, allLayers, accountId);
       if (hasWebpackPlugin(this.serverless.service)) {
         forceExcludeDepsFromWebpack(this.serverless.service);
       }
@@ -136,16 +136,16 @@ module.exports = class ServerlessPlugin {
     if (config.addExtension) {
       this.serverless.cli.log("Adding Datadog Lambda Extension Layer to functions");
       this.debugLogHandlers(handlers);
-      applyExtensionLayer(this.serverless.service, handlers, allLayers);
+      applyExtensionLayer(this.serverless.service, handlers, allLayers, accountId);
       handlers.forEach((functionInfo) => {
         if (functionInfo.type === RuntimeType.DOTNET) {
           this.serverless.cli.log("Adding .NET Tracing Layer to functions");
           this.debugLogHandlers(handlers);
-          applyDotnetTracingLayer(this.serverless.service, functionInfo, allLayers);
+          applyTracingLayer(this.serverless.service, functionInfo, allLayers, RuntimeType.DOTNET, accountId);
         } else if (functionInfo.type === RuntimeType.JAVA) {
           this.serverless.cli.log("Adding Java Tracing Layer to functions");
           this.debugLogHandlers(handlers);
-          applyJavaTracingLayer(this.serverless.service, functionInfo, allLayers);
+          applyTracingLayer(this.serverless.service, functionInfo, allLayers, RuntimeType.JAVA, accountId);
         }
       });
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,14 +138,14 @@ module.exports = class ServerlessPlugin {
       this.debugLogHandlers(handlers);
       applyExtensionLayer(this.serverless.service, handlers, allLayers, accountId);
       handlers.forEach((functionInfo) => {
-        if (functionInfo.type === RuntimeType.DOTNET) {
-          this.serverless.cli.log("Adding .NET Tracing Layer to functions");
+        if (functionInfo.type === RuntimeType.DOTNET || functionInfo.type === RuntimeType.JAVA) {
+          const runtimeNameToReadable: { [key in RuntimeType.DOTNET | RuntimeType.JAVA]: string } = {
+            [RuntimeType.DOTNET]: ".NET",
+            [RuntimeType.JAVA]: "Java",
+          };
+          this.serverless.cli.log(`Adding ${runtimeNameToReadable[functionInfo.type]} Tracing Layer to functions`);
           this.debugLogHandlers(handlers);
-          applyTracingLayer(this.serverless.service, functionInfo, allLayers, RuntimeType.DOTNET, accountId);
-        } else if (functionInfo.type === RuntimeType.JAVA) {
-          this.serverless.cli.log("Adding Java Tracing Layer to functions");
-          this.debugLogHandlers(handlers);
-          applyTracingLayer(this.serverless.service, functionInfo, allLayers, RuntimeType.JAVA, accountId);
+          applyTracingLayer(this.serverless.service, functionInfo, allLayers, functionInfo.type, accountId);
         }
       });
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,9 +121,7 @@ module.exports = class ServerlessPlugin {
     setEnvConfiguration(config, handlers);
 
     const allLayers = { regions: { ...layers.regions, ...govLayers.regions } };
-    const accountId = config.useLocalAccountLayers
-      ? await this.serverless.getProvider("aws").getAccountId()
-      : undefined;
+    const accountId = config.useLayersFromAccount;
     if (config.addLayers) {
       this.serverless.cli.log("Adding Lambda Library Layers to functions");
       this.debugLogHandlers(handlers);

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -713,7 +713,7 @@ describe("applyLambdaLibraryLayers", () => {
     });
   });
 
-  it("adds an tracing layer from the local AWS account of the same name", () => {
+  it("adds a tracing layer from the local AWS account of the same name", () => {
     const handler = {
       handler: { runtime: "java11" },
       type: RuntimeType.JAVA,
@@ -734,7 +734,7 @@ describe("applyLambdaLibraryLayers", () => {
     });
   });
 
-  it("adds an tracing layer from the local AWS account regardless of whether we've published to that region", () => {
+  it("adds a tracing layer from the local AWS account regardless of whether we've published to that region", () => {
     const handler = {
       handler: { runtime: "java11" },
       type: RuntimeType.JAVA,

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -12,6 +12,7 @@ import {
   RuntimeType,
   applyLambdaLibraryLayers,
   applyExtensionLayer,
+  applyTracingLayer,
   findHandlers,
   pushLayerARN,
 } from "./layer";
@@ -625,6 +626,132 @@ describe("applyLambdaLibraryLayers", () => {
     expect(handler.handler).toEqual({
       runtime: "python3.9",
       layers: ["python-arm:3.9", "extension-arm:11"],
+    });
+  });
+
+  it("adds a Lambda layer from the local AWS account of the same name", () => {
+    const handler = {
+      handler: { runtime: "nodejs18.x" },
+      type: RuntimeType.NODE,
+      runtime: "nodejs18.x",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: { "sa-east-1": { "nodejs18.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:1" } },
+    };
+    const mockService = createMockService("sa-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs18.x" },
+    });
+    const mockAccountId = "123456789012";
+    const localLambdaLayerARN = "arn:aws:lambda:sa-east-1:123456789012:layer:Datadog-Node18-x:1";
+    applyLambdaLibraryLayers(mockService, [handler], layers, mockAccountId);
+    expect(handler.handler).toEqual({
+      runtime: "nodejs18.x",
+      layers: [localLambdaLayerARN],
+    });
+  });
+
+  it("adds a Lambda layer from the local AWS account regardless of whether we've published to that region", () => {
+    const handler = {
+      handler: { runtime: "nodejs18.x" },
+      type: RuntimeType.NODE,
+      runtime: "nodejs18.x",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: { "us-east-1": { "nodejs18.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node18-x:1" } },
+    };
+    const mockService = createMockService("cn-north-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs18.x" },
+    });
+    const mockAccountId = "123456789012";
+    const localLambdaLayerARN = "arn:aws-cn:lambda:cn-north-1:123456789012:layer:Datadog-Node18-x:1";
+    applyLambdaLibraryLayers(mockService, [handler], layers, mockAccountId);
+    expect(handler.handler).toEqual({
+      runtime: "nodejs18.x",
+      layers: [localLambdaLayerARN],
+    });
+  });
+
+  it("adds an Extension layer from the local AWS account of the same name", () => {
+    const handler = {
+      handler: { runtime: "nodejs18.x" },
+      type: RuntimeType.NODE,
+      runtime: "nodejs18.x",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: { "us-east-1": { extension: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:1" } },
+    };
+    const mockService = createMockService("sa-east-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs18.x" },
+    });
+    const mockAccountId = "123456789012";
+    const localExtensionARN = "arn:aws:lambda:sa-east-1:123456789012:layer:Datadog-Extension:1";
+    applyExtensionLayer(mockService, [handler], layers, mockAccountId);
+    expect(handler.handler).toEqual({
+      runtime: "nodejs18.x",
+      layers: [localExtensionARN],
+    });
+  });
+
+  it("adds an Extension layer from the local AWS account regardless of whether we've published to that region", () => {
+    const handler = {
+      handler: { runtime: "nodejs18.x" },
+      type: RuntimeType.NODE,
+      runtime: "nodejs18.x",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: { "us-east-1": { extension: "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:1" } },
+    };
+    const mockService = createMockService("cn-northwest-1", {
+      "node-function": { handler: "myfile.handler", runtime: "nodejs18.x" },
+    });
+    const mockAccountId = "123456789012";
+    const localExtensionARN = "arn:aws-cn:lambda:cn-northwest-1:123456789012:layer:Datadog-Extension:1";
+    applyExtensionLayer(mockService, [handler], layers, mockAccountId);
+    expect(handler.handler).toEqual({
+      runtime: "nodejs18.x",
+      layers: [localExtensionARN],
+    });
+  });
+
+  it("adds an tracing layer from the local AWS account of the same name", () => {
+    const handler = {
+      handler: { runtime: "java11" },
+      type: RuntimeType.JAVA,
+      runtime: "java11",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: { "us-east-1": { java: "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:1" } },
+    };
+    const mockService = createMockService("sa-east-1", {
+      "java-function": { handler: "myfile.handler", runtime: "java11" },
+    });
+    const mockAccountId = "123456789012";
+    const localTraceLayerARN = "arn:aws:lambda:sa-east-1:123456789012:layer:dd-trace-java:1";
+    applyTracingLayer(mockService, handler, layers, RuntimeType.JAVA, mockAccountId);
+    expect(handler.handler).toEqual({
+      runtime: "java11",
+      layers: [localTraceLayerARN],
+    });
+  });
+
+  it("adds an tracing layer from the local AWS account regardless of whether we've published to that region", () => {
+    const handler = {
+      handler: { runtime: "java11" },
+      type: RuntimeType.JAVA,
+      runtime: "java11",
+    } as FunctionInfo;
+    const layers: LayerJSON = {
+      regions: { "us-east-1": { java: "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:1" } },
+    };
+    const mockService = createMockService("cn-northwest-1", {
+      "java-function": { handler: "myfile.handler", runtime: "java11" },
+    });
+    const mockAccountId = "123456789012";
+    const localTraceLayerARN = "arn:aws-cn:lambda:cn-northwest-1:123456789012:layer:dd-trace-java:1";
+    applyTracingLayer(mockService, handler, layers, RuntimeType.JAVA, mockAccountId);
+    expect(handler.handler).toEqual({
+      runtime: "java11",
+      layers: [localTraceLayerARN],
     });
   });
 });

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -7,15 +7,16 @@
  */
 import { FunctionDefinition, FunctionDefinitionHandler } from "serverless";
 import Service from "serverless/classes/Service";
+
 export enum RuntimeType {
-  NODE,
-  PYTHON,
-  DOTNET,
-  CUSTOM,
-  JAVA,
-  RUBY,
-  GO,
-  UNSUPPORTED,
+  NODE = "node",
+  PYTHON = "python",
+  DOTNET = "dotnet",
+  CUSTOM = "custom",
+  JAVA = "java",
+  RUBY = "ruby",
+  GO = "go",
+  UNSUPPORTED = "unsupported",
 }
 
 export interface FunctionInfo {
@@ -25,9 +26,11 @@ export interface FunctionInfo {
   runtime?: string;
 }
 
-export const X86_64_ARCHITECTURE = "x86_64";
-export const ARM64_ARCHITECTURE = "arm64";
-export const DEFAULT_ARCHITECTURE = X86_64_ARCHITECTURE;
+const X86_64_ARCHITECTURE = "x86_64";
+const ARM64_ARCHITECTURE = "arm64";
+const DEFAULT_ARCHITECTURE = X86_64_ARCHITECTURE;
+
+const DEFAULT_REGION = "us-east-1";
 
 // Separate interface since DefinitelyTyped currently doesn't include tags or env
 export interface ExtendedFunctionDefinition extends FunctionDefinition {
@@ -73,9 +76,6 @@ export const armRuntimeKeys: { [key: string]: string } = {
   dotnet6: "dd-trace-dotnet-ARM",
 };
 
-const dotnetTraceLayerKey: string = "dotnet";
-const javaTraceLayerKey: string = "java";
-
 export function findHandlers(service: Service, exclude: string[], defaultRuntime?: string): FunctionInfo[] {
   return Object.entries(service.functions)
     .map(([name, handler]) => {
@@ -94,9 +94,11 @@ export function findHandlers(service: Service, exclude: string[], defaultRuntime
     ) as FunctionInfo[];
 }
 
-export function applyLambdaLibraryLayers(service: Service, handlers: FunctionInfo[], layers: LayerJSON) {
+export function applyLambdaLibraryLayers(service: Service, handlers: FunctionInfo[], layers: LayerJSON, accountId?: string) {
   const { region } = service.provider;
-  const regionRuntimes = layers.regions[region];
+  // It's possible a local account layer is being used in a region we have not published to so we use a default region's ARNs
+  const shouldUseDefaultRegion = layers.regions[region] === undefined && accountId !== undefined;
+  const regionRuntimes = shouldUseDefaultRegion ? layers.regions[DEFAULT_REGION] : layers.regions[region];
   if (regionRuntimes === undefined) {
     return;
   }
@@ -107,24 +109,35 @@ export function applyLambdaLibraryLayers(service: Service, handlers: FunctionInf
     }
 
     const { runtime } = handler;
-    const architecture =
-      (handler.handler as any).architecture ?? (service.provider as any).architecture ?? DEFAULT_ARCHITECTURE;
-    let runtimeKey: string | undefined = runtime;
-    if (architecture === ARM64_ARCHITECTURE && runtime && runtime in armRuntimeKeys) {
-      runtimeKey = armRuntimeKeys[runtime];
-      removePreviousLayer(service, handler, regionRuntimes[runtime]);
+    if (runtime === undefined) {
+      continue;
     }
 
-    const lambdaLayerARN = runtimeKey !== undefined ? regionRuntimes[runtimeKey] : undefined;
-    if (lambdaLayerARN) {
-      addLayer(service, handler, lambdaLayerARN);
+    let runtimeKey = runtime;
+    const architecture = handler.handler?.architecture ?? (service.provider as any).architecture ?? DEFAULT_ARCHITECTURE;
+    const isArm64 = architecture === ARM64_ARCHITECTURE;
+    if (isArm64 && runtime in armRuntimeKeys) {
+      runtimeKey = armRuntimeKeys[runtime];
+      const prevLayerARN = accountId !== undefined ? buildLocalLambdaLayerARN(regionRuntimes[runtime], accountId, region) : regionRuntimes[runtime];
+      removePreviousLayer(service, handler, prevLayerARN);
+    }
+
+    let layerARN = regionRuntimes[runtimeKey];
+    if (accountId && layerARN) {
+      layerARN = buildLocalLambdaLayerARN(layerARN, accountId, region)
+    }
+
+    if (layerARN) {
+      addLayer(service, handler, layerARN);
     }
   }
 }
 
-export function applyExtensionLayer(service: Service, handlers: FunctionInfo[], layers: LayerJSON) {
+export function applyExtensionLayer(service: Service, handlers: FunctionInfo[], layers: LayerJSON, accountId?: string) {
   const { region } = service.provider;
-  const regionRuntimes = layers.regions[region];
+  // It's possible a local account layer is being used in a region we have not published to so we use a default region's ARNs
+  const shouldUseDefaultRegion = layers.regions[region] === undefined && accountId !== undefined;
+  const regionRuntimes = shouldUseDefaultRegion ? layers.regions[DEFAULT_REGION] : layers.regions[region];
   if (regionRuntimes === undefined) {
     return;
   }
@@ -135,43 +148,38 @@ export function applyExtensionLayer(service: Service, handlers: FunctionInfo[], 
     }
     const architecture =
       (handler.handler as any).architecture ?? (service.provider as any).architecture ?? DEFAULT_ARCHITECTURE;
-    let extensionLayerARN: string | undefined;
     let extensionLayerKey: string = "extension";
 
     if (architecture === ARM64_ARCHITECTURE) {
-      removePreviousLayer(service, handler, regionRuntimes[extensionLayerKey]);
+      const prevExtensionARN = accountId !== undefined ? buildLocalLambdaLayerARN(regionRuntimes[extensionLayerKey], accountId, region) : regionRuntimes[extensionLayerKey];
+      removePreviousLayer(service, handler, prevExtensionARN);
       extensionLayerKey = armRuntimeKeys[extensionLayerKey];
     }
 
-    extensionLayerARN = regionRuntimes[extensionLayerKey];
-    if (extensionLayerARN) {
-      addLayer(service, handler, extensionLayerARN);
+    let extensionARN = regionRuntimes[extensionLayerKey];
+    if (accountId && extensionARN) {
+      extensionARN = buildLocalLambdaLayerARN(extensionARN, accountId, region)
+    }
+
+    if (extensionARN) {
+      addLayer(service, handler, extensionARN);
     }
   }
 }
 
-export function applyDotnetTracingLayer(service: Service, handler: FunctionInfo, layers: LayerJSON) {
+export function applyTracingLayer(service: Service, handler: FunctionInfo, layers: LayerJSON, runtimeKey: string, accountId?: string) {
   const { region } = service.provider;
-  const regionRuntimes = layers.regions[region];
+  // It's possible a local account layer is being used in a region we have not published to so we use a default region's ARNs
+  const shouldUseDefaultRegion = layers.regions[region] === undefined && accountId !== undefined;
+  const regionRuntimes = shouldUseDefaultRegion ? layers.regions[DEFAULT_REGION] : layers.regions[region];
   if (regionRuntimes === undefined) {
     return;
   }
 
-  const traceLayerARN: string | undefined = regionRuntimes[dotnetTraceLayerKey];
-
-  if (traceLayerARN) {
-    addLayer(service, handler, traceLayerARN);
+  let traceLayerARN: string | undefined = regionRuntimes[runtimeKey];
+  if (accountId && traceLayerARN) {
+    traceLayerARN = buildLocalLambdaLayerARN(traceLayerARN, accountId, region);
   }
-}
-
-export function applyJavaTracingLayer(service: Service, handler: FunctionInfo, layers: LayerJSON) {
-  const { region } = service.provider;
-  const regionRuntimes = layers.regions[region];
-  if (regionRuntimes === undefined) {
-    return;
-  }
-
-  const traceLayerARN: string | undefined = regionRuntimes[javaTraceLayerKey];
 
   if (traceLayerARN) {
     addLayer(service, handler, traceLayerARN);
@@ -218,3 +226,24 @@ function removePreviousLayer(service: Service, handler: FunctionInfo, previousLa
 function setLayers(handler: FunctionInfo, layers: string[]) {
   (handler.handler as any).layers = layers;
 }
+
+function buildLocalLambdaLayerARN(layerARN: string | undefined, accountId: string, region: string) {
+  if (layerARN === undefined) {
+    return
+  }
+  // Rebuild the layer ARN to use the given account's region and partition
+  const [layerName, layerVersion] = layerARN.split(":").slice(6, 8)
+  const partition = getAwsPartitionByRegion(region)
+  const localLayerARN = `arn:${partition}:lambda:${region}:${accountId}:layer:${layerName}:${layerVersion}`
+  return localLayerARN
+}
+
+function getAwsPartitionByRegion(region: string) {
+  if (region.startsWith('us-gov-')) {
+      return 'aws-us-gov';
+  }
+  if (region.startsWith('cn-')) {
+      return 'aws-cn';
+  }
+  return 'aws';
+};

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -94,7 +94,12 @@ export function findHandlers(service: Service, exclude: string[], defaultRuntime
     ) as FunctionInfo[];
 }
 
-export function applyLambdaLibraryLayers(service: Service, handlers: FunctionInfo[], layers: LayerJSON, accountId?: string) {
+export function applyLambdaLibraryLayers(
+  service: Service,
+  handlers: FunctionInfo[],
+  layers: LayerJSON,
+  accountId?: string,
+) {
   const { region } = service.provider;
   // It's possible a local account layer is being used in a region we have not published to so we use a default region's ARNs
   const shouldUseDefaultRegion = layers.regions[region] === undefined && accountId !== undefined;
@@ -114,17 +119,21 @@ export function applyLambdaLibraryLayers(service: Service, handlers: FunctionInf
     }
 
     let runtimeKey = runtime;
-    const architecture = handler.handler?.architecture ?? (service.provider as any).architecture ?? DEFAULT_ARCHITECTURE;
+    const architecture =
+      handler.handler?.architecture ?? (service.provider as any).architecture ?? DEFAULT_ARCHITECTURE;
     const isArm64 = architecture === ARM64_ARCHITECTURE;
     if (isArm64 && runtime in armRuntimeKeys) {
       runtimeKey = armRuntimeKeys[runtime];
-      const prevLayerARN = accountId !== undefined ? buildLocalLambdaLayerARN(regionRuntimes[runtime], accountId, region) : regionRuntimes[runtime];
+      const prevLayerARN =
+        accountId !== undefined
+          ? buildLocalLambdaLayerARN(regionRuntimes[runtime], accountId, region)
+          : regionRuntimes[runtime];
       removePreviousLayer(service, handler, prevLayerARN);
     }
 
     let layerARN = regionRuntimes[runtimeKey];
     if (accountId && layerARN) {
-      layerARN = buildLocalLambdaLayerARN(layerARN, accountId, region)
+      layerARN = buildLocalLambdaLayerARN(layerARN, accountId, region);
     }
 
     if (layerARN) {
@@ -151,14 +160,17 @@ export function applyExtensionLayer(service: Service, handlers: FunctionInfo[], 
     let extensionLayerKey: string = "extension";
 
     if (architecture === ARM64_ARCHITECTURE) {
-      const prevExtensionARN = accountId !== undefined ? buildLocalLambdaLayerARN(regionRuntimes[extensionLayerKey], accountId, region) : regionRuntimes[extensionLayerKey];
+      const prevExtensionARN =
+        accountId !== undefined
+          ? buildLocalLambdaLayerARN(regionRuntimes[extensionLayerKey], accountId, region)
+          : regionRuntimes[extensionLayerKey];
       removePreviousLayer(service, handler, prevExtensionARN);
       extensionLayerKey = armRuntimeKeys[extensionLayerKey];
     }
 
     let extensionARN = regionRuntimes[extensionLayerKey];
     if (accountId && extensionARN) {
-      extensionARN = buildLocalLambdaLayerARN(extensionARN, accountId, region)
+      extensionARN = buildLocalLambdaLayerARN(extensionARN, accountId, region);
     }
 
     if (extensionARN) {
@@ -167,7 +179,13 @@ export function applyExtensionLayer(service: Service, handlers: FunctionInfo[], 
   }
 }
 
-export function applyTracingLayer(service: Service, handler: FunctionInfo, layers: LayerJSON, runtimeKey: string, accountId?: string) {
+export function applyTracingLayer(
+  service: Service,
+  handler: FunctionInfo,
+  layers: LayerJSON,
+  runtimeKey: string,
+  accountId?: string,
+) {
   const { region } = service.provider;
   // It's possible a local account layer is being used in a region we have not published to so we use a default region's ARNs
   const shouldUseDefaultRegion = layers.regions[region] === undefined && accountId !== undefined;
@@ -229,21 +247,21 @@ function setLayers(handler: FunctionInfo, layers: string[]) {
 
 function buildLocalLambdaLayerARN(layerARN: string | undefined, accountId: string, region: string) {
   if (layerARN === undefined) {
-    return
+    return;
   }
   // Rebuild the layer ARN to use the given account's region and partition
-  const [layerName, layerVersion] = layerARN.split(":").slice(6, 8)
-  const partition = getAwsPartitionByRegion(region)
-  const localLayerARN = `arn:${partition}:lambda:${region}:${accountId}:layer:${layerName}:${layerVersion}`
-  return localLayerARN
+  const [layerName, layerVersion] = layerARN.split(":").slice(6, 8);
+  const partition = getAwsPartitionByRegion(region);
+  const localLayerARN = `arn:${partition}:lambda:${region}:${accountId}:layer:${layerName}:${layerVersion}`;
+  return localLayerARN;
 }
 
 function getAwsPartitionByRegion(region: string) {
-  if (region.startsWith('us-gov-')) {
-      return 'aws-us-gov';
+  if (region.startsWith("us-gov-")) {
+    return "aws-us-gov";
   }
-  if (region.startsWith('cn-')) {
-      return 'aws-cn';
+  if (region.startsWith("cn-")) {
+    return "aws-cn";
   }
-  return 'aws';
-};
+  return "aws";
+}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Adds the option `useLayersFromAccount` || `DD_USE_LAYERS_FROM_ACCOUNT` to force our plugin to use DD Lambda layers of the same name published into the executing account. Note that for this special case, we make sure the feature is _region agnostic_.

Also contains some refactoring of our code.

### Motivation

<!--- What inspired you to submit this pull request? --->
Gives support for a user to download our Lambda layer, make changes and publish their own version into their account. The versioning must be on par with our latest versions (found in layers.json)

### Testing Guidelines

<!--- How did you test this pull request? --->
Added unit tests and tested manually.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
