### PR TITLE
chore: deprecate `nodejs12.x` runtime

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -181,8 +181,7 @@
                   "Effect": "Allow",
                   "Action": [
                     "logs:CreateLogStream",
-                    "logs:CreateLogGroup",
-                    "logs:TagResource"
+                    "logs:CreateLogGroup"
                   ],
                   "Resource": [
                     {

--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -95,12 +95,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-PythonHello39"
       }
     },
-    "JavascriptHello12DashxLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello12-x"
-      }
-    },
     "JavascriptHello14DashxLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -187,7 +181,8 @@
                   "Effect": "Allow",
                   "Action": [
                     "logs:CreateLogStream",
-                    "logs:CreateLogGroup"
+                    "logs:CreateLogGroup",
+                    "logs:TagResource"
                   ],
                   "Resource": [
                     {
@@ -435,56 +430,6 @@
       },
       "DependsOn": [
         "PythonHello39LogGroup"
-      ]
-    },
-    "JavascriptHello12DashxLambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
-        "Runtime": "nodejs12.x",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello12-x",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_LOG_LEVEL": "info",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": true,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev",
-            "DD_LAMBDA_HANDLER": "js_handler.hello"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "JavascriptHello12DashxLogGroup"
       ]
     },
     "JavascriptHello14DashxLambdaFunction": {
@@ -925,16 +870,6 @@
         "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello12DashxLambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "JavascriptHello12DashxLambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
     "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -1131,7 +1066,7 @@
                 ":lambda:path/2015-03-31/functions/",
                 {
                   "Fn::GetAtt": [
-                    "JavascriptHello12DashxLambdaFunction",
+                    "JavascriptHello14DashxLambdaFunction",
                     "Arn"
                   ]
                 },
@@ -1143,7 +1078,7 @@
         "MethodResponses": []
       },
       "DependsOn": [
-        "JavascriptHello12DashxLambdaPermissionApiGateway"
+        "JavascriptHello14DashxLambdaPermissionApiGateway"
       ]
     },
     "ApiGatewayDeploymentxxxx": {
@@ -1196,12 +1131,12 @@
         }
       }
     },
-    "JavascriptHello12DashxLambdaPermissionApiGateway": {
+    "JavascriptHello14DashxLambdaPermissionApiGateway": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1401,7 +1336,7 @@
         }
       }
     },
-    "JavascriptHello12DashxWebsocketsIntegration": {
+    "JavascriptHello14DashxWebsocketsIntegration": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -1423,7 +1358,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "JavascriptHello12DashxLambdaFunction",
+                  "JavascriptHello14DashxLambdaFunction",
                   "Arn"
                 ]
               },
@@ -1450,16 +1385,16 @@
         "Principal": "apigateway.amazonaws.com"
       }
     },
-    "JavascriptHello12DashxLambdaPermissionWebsockets": {
+    "JavascriptHello14DashxLambdaPermissionWebsockets": {
       "Type": "AWS::Lambda::Permission",
       "DependsOn": [
         "WebsocketsApi",
-        "JavascriptHello12DashxLambdaFunction"
+        "JavascriptHello14DashxLambdaFunction"
       ],
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1481,7 +1416,7 @@
             [
               "integrations",
               {
-                "Ref": "JavascriptHello12DashxWebsocketsIntegration"
+                "Ref": "JavascriptHello14DashxWebsocketsIntegration"
               }
             ]
           ]
@@ -1507,7 +1442,7 @@
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.eventType $context.routeKey $context.connectionId\" $context.requestId"
         },
         "DeploymentId": {
-          "Ref": "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4"
+          "Ref": "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI"
         }
       }
     },
@@ -1517,7 +1452,7 @@
         "LogGroupName": "/aws/websocket/dd-sls-plugin-integration-test-dev"
       }
     },
-    "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4": {
+    "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI": {
       "Type": "AWS::ApiGatewayV2::Deployment",
       "DependsOn": [
         "SconnectWebsocketsRoute",
@@ -1641,12 +1576,12 @@
       },
       "DependsOn": "HttpApiIntegrationPythonHello39"
     },
-    "JavascriptHello12DashxLambdaPermissionHttpApi": {
+    "JavascriptHello14DashxLambdaPermissionHttpApi": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1678,7 +1613,7 @@
         }
       }
     },
-    "HttpApiIntegrationJavascriptHello12Dashx": {
+    "HttpApiIntegrationJavascriptHello14Dashx": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -1687,7 +1622,7 @@
         "IntegrationType": "AWS_PROXY",
         "IntegrationUri": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1708,13 +1643,13 @@
             [
               "integrations",
               {
-                "Ref": "HttpApiIntegrationJavascriptHello12Dashx"
+                "Ref": "HttpApiIntegrationJavascriptHello14Dashx"
               }
             ]
           ]
         }
       },
-      "DependsOn": "HttpApiIntegrationJavascriptHello12Dashx"
+      "DependsOn": "HttpApiIntegrationJavascriptHello14Dashx"
     },
     "ApiGatewayLogGroupSubscription": {
       "Type": "AWS::Logs::SubscriptionFilter",
@@ -1790,15 +1725,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-PythonHello39LambdaFunctionQualifiedArn"
-      }
-    },
-    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -187,8 +187,7 @@
                   "Effect": "Allow",
                   "Action": [
                     "logs:CreateLogStream",
-                    "logs:CreateLogGroup",
-                    "logs:TagResource"
+                    "logs:CreateLogGroup"
                   ],
                   "Resource": [
                     {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -95,12 +95,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-PythonHello39"
       }
     },
-    "JavascriptHello12DashxLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello12-x"
-      }
-    },
     "JavascriptHello14DashxLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -193,7 +187,8 @@
                   "Effect": "Allow",
                   "Action": [
                     "logs:CreateLogStream",
-                    "logs:CreateLogGroup"
+                    "logs:CreateLogGroup",
+                    "logs:TagResource"
                   ],
                   "Resource": [
                     {
@@ -232,6 +227,19 @@
         }
       }
     },
+    "FunctionLevelLayerLambdaLayer": {
+      "Type": "AWS::Lambda::LayerVersion",
+      "Properties": {
+        "Content": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/FunctionLevelLayer.zip"
+        },
+        "LayerName": "dd-sls-plugin-integration-test-dev-FunctionLevelLayer",
+        "Description": "It's also a text file"
+      }
+    },
     "ProviderLevelLayerLambdaLayer": {
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
@@ -244,21 +252,8 @@
         "LayerName": "dd-sls-plugin-integration-test-dev-ProviderLevelLayer",
         "Description": "It's a text file",
         "CompatibleRuntimes": [
-          "nodejs12.x"
+          "nodejs14.x"
         ]
-      }
-    },
-    "FunctionLevelLayerLambdaLayer": {
-      "Type": "AWS::Lambda::LayerVersion",
-      "Properties": {
-        "Content": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/FunctionLevelLayer.zip"
-        },
-        "LayerName": "dd-sls-plugin-integration-test-dev-FunctionLevelLayer",
-        "Description": "It's also a text file"
       }
     },
     "PythonHello36LambdaFunction": {
@@ -469,58 +464,6 @@
         "PythonHello39LogGroup"
       ]
     },
-    "JavascriptHello12DashxLambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
-        "Runtime": "nodejs12.x",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello12-x",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": true,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev",
-            "DD_LAMBDA_HANDLER": "js_handler.hello"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          {
-            "Ref": "FunctionLevelLayerLambdaLayer"
-          },
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "JavascriptHello12DashxLogGroup"
-      ]
-    },
     "JavascriptHello14DashxLambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -563,7 +506,7 @@
         },
         "Layers": [
           {
-            "Ref": "ProviderLevelLayerLambdaLayer"
+            "Ref": "FunctionLevelLayerLambdaLayer"
           },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
@@ -968,12 +911,12 @@
         "ProvidedHelloLogGroup"
       ]
     },
-    "JavascriptHello12DashxLambdaVersionXXXX": {
+    "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
-          "Ref": "JavascriptHello12DashxLambdaFunction"
+          "Ref": "JavascriptHello14DashxLambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1014,16 +957,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello39LambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
-    "JavascriptHello14DashxLambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "JavascriptHello14DashxLambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1118,29 +1051,6 @@
         "Name": "sls-dd-sls-plugin-integration-test-dev-ServerlessDeploymentBucketName"
       }
     },
-    "ProviderLevelLayerLambdaLayerQualifiedArn": {
-      "Description": "Current Lambda layer version",
-      "Value": {
-        "Ref": "ProviderLevelLayerLambdaLayer"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerQualifiedArn"
-      }
-    },
-    "ProviderLevelLayerLambdaLayerHash": {
-      "Description": "Current Lambda layer hash",
-      "Value": "ca99f65eb22bc573edd4f9ac2a087d0dd5acc751",
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerHash"
-      }
-    },
-    "ProviderLevelLayerLambdaLayerS3Key": {
-      "Description": "Current Lambda layer S3Key",
-      "Value": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/ProviderLevelLayer.zip",
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerS3Key"
-      }
-    },
     "FunctionLevelLayerLambdaLayerQualifiedArn": {
       "Description": "Current Lambda layer version",
       "Value": {
@@ -1164,13 +1074,36 @@
         "Name": "sls-dd-sls-plugin-integration-test-dev-FunctionLevelLayerLambdaLayerS3Key"
       }
     },
-    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
+    "ProviderLevelLayerLambdaLayerQualifiedArn": {
+      "Description": "Current Lambda layer version",
       "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
+        "Ref": "ProviderLevelLayerLambdaLayer"
       },
       "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
+        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerQualifiedArn"
+      }
+    },
+    "ProviderLevelLayerLambdaLayerHash": {
+      "Description": "Current Lambda layer hash",
+      "Value": "9fc1163e4a4e81d5019bc0e9d4f63aa54d97576f",
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerHash"
+      }
+    },
+    "ProviderLevelLayerLambdaLayerS3Key": {
+      "Description": "Current Lambda layer S3Key",
+      "Value": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/ProviderLevelLayer.zip",
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerS3Key"
+      }
+    },
+    "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "JavascriptHello14DashxLambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello14DashxLambdaFunctionQualifiedArn"
       }
     },
     "PythonHello36LambdaFunctionQualifiedArn": {
@@ -1207,15 +1140,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-PythonHello39LambdaFunctionQualifiedArn"
-      }
-    },
-    "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "JavascriptHello14DashxLambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello14DashxLambdaFunctionQualifiedArn"
       }
     },
     "JavascriptHello16DashxLambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -193,8 +193,7 @@
                   "Effect": "Allow",
                   "Action": [
                     "logs:CreateLogStream",
-                    "logs:CreateLogGroup",
-                    "logs:TagResource"
+                    "logs:CreateLogGroup"
                   ],
                   "Resource": [
                     {

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -95,12 +95,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-PythonHello39"
       }
     },
-    "JavascriptHello12DashxLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello12-x"
-      }
-    },
     "JavascriptHello14DashxLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -199,7 +193,8 @@
                   "Effect": "Allow",
                   "Action": [
                     "logs:CreateLogStream",
-                    "logs:CreateLogGroup"
+                    "logs:CreateLogGroup",
+                    "logs:TagResource"
                   ],
                   "Resource": [
                     {
@@ -286,16 +281,6 @@
         "FilterPattern": "",
         "LogGroupName": {
           "Ref": "PythonHello39LogGroup"
-        }
-      }
-    },
-    "JavascriptHello12DashxLogGroupSubscription": {
-      "Type": "AWS::Logs::SubscriptionFilter",
-      "Properties": {
-        "DestinationArn": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
-        "FilterPattern": "",
-        "LogGroupName": {
-          "Ref": "JavascriptHello12DashxLogGroup"
         }
       }
     },
@@ -701,61 +686,6 @@
       },
       "DependsOn": [
         "PythonHello39LogGroup"
-      ]
-    },
-    "JavascriptHello12DashxLambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
-        "Runtime": "nodejs12.x",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello12-x",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_SITE": "datadoghq.com",
-            "DD_LOG_LEVEL": "info",
-            "DD_FLUSH_TO_LOG": true,
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": true,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_LAMBDA_HANDLER": "js_handler.hello"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX"
-        ]
-      },
-      "DependsOn": [
-        "JavascriptHello12DashxLogGroup"
       ]
     },
     "JavascriptHello14DashxLambdaFunction": {
@@ -1268,16 +1198,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "PythonHello39LambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
-    "JavascriptHello12DashxLambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "JavascriptHello12DashxLambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1853,7 +1773,7 @@
                 ":lambda:path/2015-03-31/functions/",
                 {
                   "Fn::GetAtt": [
-                    "JavascriptHello12DashxLambdaFunction",
+                    "JavascriptHello14DashxLambdaFunction",
                     "Arn"
                   ]
                 },
@@ -1865,7 +1785,7 @@
         "MethodResponses": []
       },
       "DependsOn": [
-        "JavascriptHello12DashxLambdaPermissionApiGateway"
+        "JavascriptHello14DashxLambdaPermissionApiGateway"
       ]
     },
     "ApiGatewayDeploymentxxxx": {
@@ -1918,12 +1838,12 @@
         }
       }
     },
-    "JavascriptHello12DashxLambdaPermissionApiGateway": {
+    "JavascriptHello14DashxLambdaPermissionApiGateway": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2123,7 +2043,7 @@
         }
       }
     },
-    "JavascriptHello12DashxWebsocketsIntegration": {
+    "JavascriptHello14DashxWebsocketsIntegration": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -2145,7 +2065,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "JavascriptHello12DashxLambdaFunction",
+                  "JavascriptHello14DashxLambdaFunction",
                   "Arn"
                 ]
               },
@@ -2172,16 +2092,16 @@
         "Principal": "apigateway.amazonaws.com"
       }
     },
-    "JavascriptHello12DashxLambdaPermissionWebsockets": {
+    "JavascriptHello14DashxLambdaPermissionWebsockets": {
       "Type": "AWS::Lambda::Permission",
       "DependsOn": [
         "WebsocketsApi",
-        "JavascriptHello12DashxLambdaFunction"
+        "JavascriptHello14DashxLambdaFunction"
       ],
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2203,7 +2123,7 @@
             [
               "integrations",
               {
-                "Ref": "JavascriptHello12DashxWebsocketsIntegration"
+                "Ref": "JavascriptHello14DashxWebsocketsIntegration"
               }
             ]
           ]
@@ -2229,7 +2149,7 @@
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.eventType $context.routeKey $context.connectionId\" $context.requestId"
         },
         "DeploymentId": {
-          "Ref": "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4"
+          "Ref": "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI"
         }
       }
     },
@@ -2239,7 +2159,7 @@
         "LogGroupName": "/aws/websocket/dd-sls-plugin-integration-test-dev"
       }
     },
-    "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4": {
+    "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI": {
       "Type": "AWS::ApiGatewayV2::Deployment",
       "DependsOn": [
         "SconnectWebsocketsRoute",
@@ -2347,12 +2267,12 @@
       },
       "DependsOn": "HttpApiIntegrationPythonHello39"
     },
-    "JavascriptHello12DashxLambdaPermissionHttpApi": {
+    "JavascriptHello14DashxLambdaPermissionHttpApi": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2384,7 +2304,7 @@
         }
       }
     },
-    "HttpApiIntegrationJavascriptHello12Dashx": {
+    "HttpApiIntegrationJavascriptHello14Dashx": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -2393,7 +2313,7 @@
         "IntegrationType": "AWS_PROXY",
         "IntegrationUri": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2414,13 +2334,13 @@
             [
               "integrations",
               {
-                "Ref": "HttpApiIntegrationJavascriptHello12Dashx"
+                "Ref": "HttpApiIntegrationJavascriptHello14Dashx"
               }
             ]
           ]
         }
       },
-      "DependsOn": "HttpApiIntegrationJavascriptHello12Dashx"
+      "DependsOn": "HttpApiIntegrationJavascriptHello14Dashx"
     },
     "ApiGatewayLogGroupSubscription": {
       "Type": "AWS::Logs::SubscriptionFilter",
@@ -2498,15 +2418,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-PythonHello39LambdaFunctionQualifiedArn"
-      }
-    },
-    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {

--- a/integration_tests/serverless-extension-apigateway.yml
+++ b/integration_tests/serverless-extension-apigateway.yml
@@ -42,9 +42,9 @@ functions:
           path: /users/update
           method: put
       - websocket: $connect
-  JavascriptHello12-x:
+  JavascriptHello14-x:
     handler: js_handler.hello
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     events:
       - http:
           path: users/create
@@ -53,9 +53,6 @@ functions:
           path: /users/remove
           method: delete
       - websocket: $connect
-  JavascriptHello14-x:
-    handler: js_handler.hello
-    runtime: nodejs14.x
   JavascriptHello16-x:
     handler: js_handler.hello
     runtime: nodejs16.x

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -32,14 +32,11 @@ functions:
   PythonHello39:
     handler: py_handler.hello
     runtime: python3.9
-  JavascriptHello12-x:
-    handler: js_handler.hello
-    runtime: nodejs12.x
-    layers:
-      - { Ref: FunctionLevelLayerLambdaLayer }
   JavascriptHello14-x:
     handler: js_handler.hello
     runtime: nodejs14.x
+    layers:
+      - { Ref: FunctionLevelLayerLambdaLayer }
   JavascriptHello16-x:
     handler: js_handler.hello
     runtime: nodejs16.x
@@ -70,7 +67,7 @@ layers:
     name: ${self:service}-${sls:stage}-ProviderLevelLayer # optional, Deployed Lambda layer name
     description: It's a text file # optional, Description to publish to AWS
     compatibleRuntimes: # optional, a list of runtimes this layer is compatible with
-      - nodejs12.x
+      - nodejs14.x
   FunctionLevelLayer:
     path: FunctionLevelLayer
     name: ${self:service}-${sls:stage}-FunctionLevelLayer # optional, Deployed Lambda layer name

--- a/integration_tests/serverless-forwarder.yml
+++ b/integration_tests/serverless-forwarder.yml
@@ -48,9 +48,9 @@ functions:
           path: /users/update
           method: put
       - websocket: $connect
-  JavascriptHello12-x:
+  JavascriptHello14-x:
     handler: js_handler.hello
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     events:
       - http:
           path: users/create
@@ -59,9 +59,6 @@ functions:
           path: /users/remove
           method: delete
       - websocket: $connect
-  JavascriptHello14-x:
-    handler: js_handler.hello
-    runtime: nodejs14.x
   JavascriptHello16-x:
     handler: js_handler.hello
     runtime: nodejs16.x

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "python3.6" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "extension" "extension-arm" "dotnet" "java")
+LAYER_NAMES=("Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-java")
+JSON_LAYER_NAMES=("nodejs14.x" "nodejs16.x" "nodejs18.x" "python3.6" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "extension" "extension-arm" "dotnet" "java")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 FILE_NAME="src/layers.json"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -48,7 +48,7 @@ for ((i = 0; i < ${#SERVERLESS_CONFIGS[@]}; i++)); do
     # Normalize dd_sls_plugin version tag value
     perl -p -i -e 's/(v\d+.\d+.\d+)/vX.XX.X/g' ${RAW_CFN_TEMPLATE}
     # Normalize Datadog Layer Arn versions
-    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:(Datadog-(Python36|Python37|Python38|Python39|Node12-x|Node14-x|Node16-x|Node18-x|Extension)|dd-trace-(dotnet|java)):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:\2:XXX/g' ${RAW_CFN_TEMPLATE}
+    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:(Datadog-(Python36|Python37|Python38|Python39|Node14-x|Node16-x|Node18-x|Extension)|dd-trace-(dotnet|java)):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:\2:XXX/g' ${RAW_CFN_TEMPLATE}
     # Normalize API Gateway timestamps
     perl -p -i -e 's/("ApiGatewayDeployment.*")/"ApiGatewayDeploymentxxxx"/g' ${RAW_CFN_TEMPLATE}
     # Normalize layer timestamps

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -914,7 +914,7 @@ describe("setEnvConfiguration", () => {
         handler: {
           environment: {},
           events: [],
-          runtime: "nodejs12.x",
+          runtime: "nodejs18.x",
         },
         name: "function",
         type: RuntimeType.NODE,

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -43,7 +43,6 @@ describe("findHandlers", () => {
   it("finds all node and python layers with matching layers", () => {
     const mockService = createMockService("us-east-1", {
       "go-function": { handler: "myfile.handler", runtime: "go1.10" },
-      "node12-function": { handler: "myfile.handler", runtime: "nodejs12.x" },
       "node14-function": { handler: "myfile.handler", runtime: "nodejs14.x" },
       "node16-function": { handler: "myfile.handler", runtime: "nodejs16.x" },
       "node18-function": { handler: "myfile.handler", runtime: "nodejs18.x" },
@@ -68,12 +67,6 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "go1.10" },
         type: RuntimeType.UNSUPPORTED,
         runtime: "go1.10",
-      },
-      {
-        name: "node12-function",
-        handler: { handler: "myfile.handler", runtime: "nodejs12.x" },
-        type: RuntimeType.NODE,
-        runtime: "nodejs12.x",
       },
       {
         name: "node14-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -48,7 +48,6 @@ export interface LayerJSON {
 }
 
 export const runtimeLookup: { [key: string]: RuntimeType } = {
-  "nodejs12.x": RuntimeType.NODE,
   "nodejs14.x": RuntimeType.NODE,
   "nodejs16.x": RuntimeType.NODE,
   "nodejs18.x": RuntimeType.NODE,

--- a/src/layers-gov.json
+++ b/src/layers-gov.json
@@ -1,7 +1,6 @@
 {
   "regions": {
     "us-gov-west-1": {
-      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Node18-x:91",
@@ -19,7 +18,6 @@
       "java": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-java:10"
     },
     "us-gov-east-1": {
-      "nodejs12.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Node18-x:91",

--- a/src/layers.json
+++ b/src/layers.json
@@ -1,7 +1,6 @@
 {
   "regions": {
     "af-south-1": {
-      "nodejs12.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Node18-x:91",
@@ -19,7 +18,6 @@
       "java": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:10"
     },
     "ap-south-1": {
-      "nodejs12.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Node18-x:91",
@@ -37,7 +35,6 @@
       "java": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:10"
     },
     "eu-north-1": {
-      "nodejs12.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Node18-x:91",
@@ -55,7 +52,6 @@
       "java": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:10"
     },
     "eu-west-3": {
-      "nodejs12.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Node18-x:91",
@@ -73,7 +69,6 @@
       "java": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:10"
     },
     "eu-south-1": {
-      "nodejs12.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Node18-x:91",
@@ -91,7 +86,6 @@
       "java": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:10"
     },
     "eu-west-2": {
-      "nodejs12.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Node18-x:91",
@@ -109,7 +103,6 @@
       "java": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:10"
     },
     "eu-west-1": {
-      "nodejs12.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Node18-x:91",
@@ -127,7 +120,6 @@
       "java": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:10"
     },
     "ap-northeast-3": {
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Node18-x:91",
@@ -145,7 +137,6 @@
       "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:10"
     },
     "ap-northeast-2": {
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Node18-x:91",
@@ -163,7 +154,6 @@
       "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:10"
     },
     "me-south-1": {
-      "nodejs12.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Node18-x:91",
@@ -181,7 +171,6 @@
       "java": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:10"
     },
     "ap-northeast-1": {
-      "nodejs12.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Node18-x:91",
@@ -199,7 +188,6 @@
       "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:10"
     },
     "me-central-1": {
-      "nodejs12.x": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Node18-x:91",
@@ -216,7 +204,6 @@
       "java": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-java:10"
     },
     "ca-central-1": {
-      "nodejs12.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Node18-x:91",
@@ -234,7 +221,6 @@
       "java": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:10"
     },
     "sa-east-1": {
-      "nodejs12.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:91",
@@ -252,7 +238,6 @@
       "java": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:10"
     },
     "ap-east-1": {
-      "nodejs12.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Node18-x:91",
@@ -270,7 +255,6 @@
       "java": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:10"
     },
     "ap-southeast-1": {
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Node18-x:91",
@@ -288,7 +272,6 @@
       "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:10"
     },
     "ap-southeast-2": {
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Node18-x:91",
@@ -306,7 +289,6 @@
       "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:10"
     },
     "eu-central-1": {
-      "nodejs12.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Node18-x:91",
@@ -324,7 +306,6 @@
       "java": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:10"
     },
     "ap-southeast-3": {
-      "nodejs12.x": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Node18-x:91",
@@ -341,7 +322,6 @@
       "java": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-java:10"
     },
     "us-east-1": {
-      "nodejs12.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node18-x:91",
@@ -359,7 +339,6 @@
       "java": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:10"
     },
     "us-east-2": {
-      "nodejs12.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Node18-x:91",
@@ -377,7 +356,6 @@
       "java": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:10"
     },
     "us-west-1": {
-      "nodejs12.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Node18-x:91",
@@ -395,7 +373,6 @@
       "java": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:10"
     },
     "us-west-2": {
-      "nodejs12.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node12-x:88",
       "nodejs14.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node14-x:91",
       "nodejs16.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node16-x:91",
       "nodejs18.x": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Node18-x:91",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Removes `nodejs12.x` runtime from this plugin.

### Motivation

This runtime has been deprecated by AWS.

### Testing Guidelines

n/a

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
