### PR TITLE
feat: Move datadog hook back to before:package:createDeploymentArtifa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ custom:
 
 - The Datadog Lambda Extension is now the default mechanism for transmitting telemetry to Datadog.
 
+## Working with serverless-plugin-warmup
+This library is compatible at best effort with [serverless-plugin-warmup](https://github.com/juanjoDiaz/serverless-plugin-warmup). If you want to exclude the warmer function from Datadog, you can dot hat with the `exclude` feature of this library.
+
+To properly package your application this plugin *must* be listed _after_ `serverless-plugin-warmup` in your `serverless.yml` file:
+```yaml
+plugins:
+  - serverless-plugin-warmup
+  - serverless-plugin-datadog
+```
+
 ## Opening Issues
 
 If you encounter a bug with this package, let us know by filing an issue! Before opening a new issue, please search the existing issues to avoid duplicates.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ custom:
 ## Working with serverless-plugin-warmup
 This library is compatible at best effort with [serverless-plugin-warmup](https://github.com/juanjoDiaz/serverless-plugin-warmup). If you want to exclude the warmer function from Datadog, use the `exclude` feature of this library.
 
-To properly package your application this plugin *must* be listed _after_ `serverless-plugin-warmup` in your `serverless.yml` file:
+To properly package your application, this plugin *must* be listed _after_ `serverless-plugin-warmup` in your `serverless.yml` file:
 ```yaml
 plugins:
   - serverless-plugin-warmup

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ custom:
 - The Datadog Lambda Extension is now the default mechanism for transmitting telemetry to Datadog.
 
 ## Working with serverless-plugin-warmup
-This library is compatible at best effort with [serverless-plugin-warmup](https://github.com/juanjoDiaz/serverless-plugin-warmup). If you want to exclude the warmer function from Datadog, you can dot hat with the `exclude` feature of this library.
+This library is compatible at best effort with [serverless-plugin-warmup](https://github.com/juanjoDiaz/serverless-plugin-warmup). If you want to exclude the warmer function from Datadog, use the `exclude` feature of this library.
 
 To properly package your application this plugin *must* be listed _after_ `serverless-plugin-warmup` in your `serverless.yml` file:
 ```yaml

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -84,7 +84,7 @@ describe("ServerlessPlugin", () => {
       };
 
       const plugin = new ServerlessPlugin(serverless, {});
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
       expect(serverless).toMatchObject({
         service: {
           functions: {
@@ -134,7 +134,7 @@ describe("ServerlessPlugin", () => {
       };
 
       const plugin = new ServerlessPlugin(serverless, {});
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
       expect(serverless).toMatchObject({
         service: {
           functions: {
@@ -181,7 +181,7 @@ describe("ServerlessPlugin", () => {
       };
 
       const plugin = new ServerlessPlugin(serverless, {});
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
       expect(serverless).toMatchObject({
         service: {
           functions: {
@@ -230,7 +230,7 @@ describe("ServerlessPlugin", () => {
       };
 
       const plugin = new ServerlessPlugin(serverless, {});
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
       expect(serverless).toMatchObject({
         service: {
           functions: {
@@ -275,7 +275,7 @@ describe("ServerlessPlugin", () => {
       };
 
       const plugin = new ServerlessPlugin(serverless, {});
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
       expect(serverless).toMatchObject({
         service: {
           functions: {
@@ -321,7 +321,7 @@ describe("ServerlessPlugin", () => {
       };
 
       const plugin = new ServerlessPlugin(serverless, {});
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
       expect(serverless).toMatchObject({
         service: {
           functions: {
@@ -374,7 +374,7 @@ describe("ServerlessPlugin", () => {
     };
 
     const plugin = new ServerlessPlugin(serverless, {});
-    await plugin.hooks["after:package:initialize"]();
+    await plugin.hooks["before:package:createDeploymentArtifacts"]();
     expect(serverless).toMatchObject({
       service: {
         functions: {
@@ -422,7 +422,7 @@ describe("ServerlessPlugin", () => {
     };
 
     const plugin = new ServerlessPlugin(serverless, {});
-    await plugin.hooks["after:package:initialize"]();
+    await plugin.hooks["before:package:createDeploymentArtifacts"]();
     expect(serverless).toMatchObject({
       service: {
         functions: {
@@ -470,7 +470,7 @@ describe("ServerlessPlugin", () => {
     };
 
     const plugin = new ServerlessPlugin(serverless, {});
-    await plugin.hooks["after:package:initialize"]();
+    await plugin.hooks["before:package:createDeploymentArtifacts"]();
     expect(serverless).toMatchObject({
       service: {
         functions: {
@@ -518,7 +518,7 @@ describe("ServerlessPlugin", () => {
     };
 
     const plugin = new ServerlessPlugin(serverless, {});
-    await plugin.hooks["after:package:initialize"]();
+    await plugin.hooks["before:package:createDeploymentArtifacts"]();
     expect(serverless).toMatchObject({
       service: {
         functions: {
@@ -578,7 +578,7 @@ describe("ServerlessPlugin", () => {
       let threwError: boolean = false;
       let thrownErrorMessage: string | undefined;
       try {
-        await plugin.hooks["after:package:initialize"]();
+        await plugin.hooks["before:package:createDeploymentArtifacts"]();
       } catch (e) {
         threwError = true;
         if (e instanceof Error) {
@@ -620,7 +620,7 @@ describe("ServerlessPlugin", () => {
       let threwError: boolean = false;
       let thrownErrorMessage: string | undefined;
       try {
-        await plugin.hooks["after:package:initialize"]();
+        await plugin.hooks["before:package:createDeploymentArtifacts"]();
       } catch (e) {
         threwError = true;
         if (e instanceof Error) {
@@ -660,7 +660,7 @@ describe("ServerlessPlugin", () => {
       let threwError: boolean = false;
       let thrownErrorMessage: string | undefined;
       try {
-        await plugin.hooks["after:package:initialize"]();
+        await plugin.hooks["before:package:createDeploymentArtifacts"]();
       } catch (e) {
         threwError = true;
         if (e instanceof Error) {
@@ -700,7 +700,7 @@ describe("ServerlessPlugin", () => {
       let threwError: boolean = false;
       let thrownErrorMessage: string | undefined;
       try {
-        await plugin.hooks["after:package:initialize"]();
+        await plugin.hooks["before:package:createDeploymentArtifacts"]();
       } catch (e) {
         threwError = true;
         if (e instanceof Error) {
@@ -739,7 +739,7 @@ describe("ServerlessPlugin", () => {
       let threwError: boolean = false;
       let thrownErrorMessage: string | undefined;
       try {
-        await plugin.hooks["after:package:initialize"]();
+        await plugin.hooks["before:package:createDeploymentArtifacts"]();
       } catch (e) {
         threwError = true;
         if (e instanceof Error) {
@@ -783,7 +783,7 @@ describe("ServerlessPlugin", () => {
       const plugin = new ServerlessPlugin(serverless, {});
       let threwError: boolean = false;
       try {
-        await plugin.hooks["after:package:initialize"]();
+        await plugin.hooks["before:package:createDeploymentArtifacts"]();
       } catch (e) {
         threwError = true;
         if (e instanceof Error) {
@@ -822,7 +822,7 @@ describe("ServerlessPlugin", () => {
       let threwError: boolean = false;
       let thrownErrorMessage: string | undefined;
       try {
-        await plugin.hooks["after:package:initialize"]();
+        await plugin.hooks["before:package:createDeploymentArtifacts"]();
       } catch (e) {
         threwError = true;
         if (e instanceof Error) {
@@ -869,7 +869,7 @@ describe("ServerlessPlugin", () => {
     const plugin = new ServerlessPlugin(serverless, {});
     let threwError: boolean = false;
     try {
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
     } catch (e) {
       threwError = true;
     }
@@ -909,7 +909,7 @@ describe("ServerlessPlugin", () => {
     const plugin = new ServerlessPlugin(serverless, {});
     let threwError: boolean = false;
     try {
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
     } catch (e) {
       threwError = true;
     }
@@ -947,7 +947,7 @@ describe("ServerlessPlugin", () => {
     let threwError: boolean = false;
     let thrownErrorMessage: string | undefined;
     try {
-      await plugin.hooks["after:package:initialize"]();
+      await plugin.hooks["before:package:createDeploymentArtifacts"]();
     } catch (e) {
       threwError = true;
       if (e instanceof Error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ module.exports = class ServerlessPlugin {
     "after:datadog:generate:init": this.beforePackageFunction.bind(this),
     "after:deploy:function:packageFunction": this.afterPackageFunction.bind(this),
     "after:package:createDeploymentArtifacts": this.afterPackageFunction.bind(this),
-    "after:package:initialize": this.beforePackageFunction.bind(this),
+    "before:package:createDeploymentArtifacts": this.beforePackageFunction.bind(this),
     "after:package:compileFunctions": this.afterPackageCompileFunctions.bind(this),
     "before:deploy:function:packageFunction": this.beforePackageFunction.bind(this),
     "before:offline:start:init": this.beforePackageFunction.bind(this),


### PR DESCRIPTION
…cts instead of after:package:Initialize

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Had a great discussion w/ the author of [serverless-plugin-warmup](https://github.com/juanjoDiaz/serverless-plugin-warmup/issues/231) and realized we could probably fix the warmup issues with two changes:
1. Moving our hook `back` in the logical order of hooks from `after:package:initialize` to `before:package:createDeploymentArtifacts`.

This is necessary to cooperate with the `warmup` plugin which needs to inject actual code after bundlers like webpack run.

Our library only sets config, so we only need to move the hook here to accommodate `serverless-plugin-warmup`.

Reasoning from author:
```
The warmup lambdas are added on the after:package:initialize event. Which is the same event used by the datadog plugin.
However, the webpack, bundle and similar plugins use the before:package:createDeploymentArtifacts event and break things.
For that, I need to reset the warmers during the before:package:createDeploymentArtifacts event.
I wish I could get rid of that hack but then I'd break the library for all people bundling their JS.
```

2. For this to work, Datadog has to be listed _after_ `serverless-plugin-warmup`. I've added this in the readme.

### Motivation
Fully fixes our side of https://github.com/juanjoDiaz/serverless-plugin-warmup/issues/231

### Testing Guidelines
I ran this locally and tested to confirm it packages valid cloudformation for the warmer as well as my other function in the stack:
<img width="463" alt="image" src="https://github.com/DataDog/serverless-plugin-datadog/assets/1598537/e3709ea9-cf7b-4bd9-bd1f-52d926f8cee2">

I manually added the `ASTUYVE` line into a local build of `serverless-plugin-warmup` to verify.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
