### PR TITLE
Search monitor patch

### DIFF
--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -170,37 +170,39 @@ describe("searchMonitor", () => {
       status: 200,
       json: () => ({
         metadata: { total_count: 3, page: 0, per_page: 30, page_count: 1 },
-        monitors: [{
-          status: "No Data",
-          scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
-          classification: "metric",
-          creator: {
-            handle: "datadog@datadoghq.com",
+        monitors: [
+          {
+            status: "No Data",
+            scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
+            classification: "metric",
+            creator: {
+              handle: "datadog@datadoghq.com",
+              id: 1234567,
+              name: "H Jiang",
+            },
+            metrics: ["aws.lambda.enhanced.estimated_cost"],
+            notifications: [],
+            muted_until_ts: null,
+            query:
+              "pct_change(avg(last_5m),last_5m):avg:aws.lambda.enhanced.estimated_cost{aws_cloudformation_stack-id:cloudformation_stack_id} > 20",
             id: 1234567,
-            name: "H Jiang",
+            last_triggered_ts: null,
+            name: "Increased Cost",
+            tags: [
+              "service:plugin-demo-ts",
+              "created_by:dd_sls_plugin",
+              "serverless_monitor_type:single_function",
+              "aws_cloudformation_stack-id:cloudformation_stack_id",
+              "serverless_monitor_id:increased_cost",
+              "env:dev",
+            ],
+            org_id: 1234567,
+            priority: null,
+            overall_state_modified: 1234567,
+            restricted_roles: [],
+            type: "query alert",
           },
-          metrics: ["aws.lambda.enhanced.estimated_cost"],
-          notifications: [],
-          muted_until_ts: null,
-          query:
-            "pct_change(avg(last_5m),last_5m):avg:aws.lambda.enhanced.estimated_cost{aws_cloudformation_stack-id:cloudformation_stack_id} > 20",
-          id: 1234567,
-          last_triggered_ts: null,
-          name: "Increased Cost",
-          tags: [
-            "service:plugin-demo-ts",
-            "created_by:dd_sls_plugin",
-            "serverless_monitor_type:single_function",
-            "aws_cloudformation_stack-id:cloudformation_stack_id",
-            "serverless_monitor_id:increased_cost",
-            "env:dev",
-          ],
-          org_id: 1234567,
-          priority: null,
-          overall_state_modified: 1234567,
-          restricted_roles: [],
-          type: "query alert",
-        }],
+        ],
       }),
     });
     const response = await searchMonitors("datadoghq.com", "queryTag", "apikey", "appkey");
@@ -237,79 +239,84 @@ describe("searchMonitor", () => {
     });
   });
   it("returns multiple pages of monitor data", async () => {
-    const fetchMock = (fetch as unknown as jest.Mock).mockReturnValueOnce({
-      status: 200,
-      json: () => ({
-        metadata: { total_count: 2, page: 0, per_page: 1, page_count: 2 },
-        monitors: [{
-          status: "No Data",
-          scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
-          classification: "metric",
-          creator: {
-            handle: "datadog@datadoghq.com",
-            id: 1234567,
-            name: "H Jiang",
-          },
-          metrics: ["aws.lambda.enhanced.estimated_cost"],
-          notifications: [],
-          muted_until_ts: null,
-          query:
-            "pct_change(avg(last_5m),last_5m):avg:aws.lambda.enhanced.estimated_cost{aws_cloudformation_stack-id:cloudformation_stack_id} > 20",
-          id: 1234567,
-          last_triggered_ts: null,
-          name: "Increased Cost",
-          tags: [
-            "service:plugin-demo-ts",
-            "created_by:dd_sls_plugin",
-            "serverless_monitor_type:single_function",
-            "aws_cloudformation_stack-id:cloudformation_stack_id",
-            "serverless_monitor_id:increased_cost",
-            "env:dev",
+    const fetchMock = (fetch as unknown as jest.Mock)
+      .mockReturnValueOnce({
+        status: 200,
+        json: () => ({
+          metadata: { total_count: 2, page: 0, per_page: 1, page_count: 2 },
+          monitors: [
+            {
+              status: "No Data",
+              scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
+              classification: "metric",
+              creator: {
+                handle: "datadog@datadoghq.com",
+                id: 1234567,
+                name: "H Jiang",
+              },
+              metrics: ["aws.lambda.enhanced.estimated_cost"],
+              notifications: [],
+              muted_until_ts: null,
+              query:
+                "pct_change(avg(last_5m),last_5m):avg:aws.lambda.enhanced.estimated_cost{aws_cloudformation_stack-id:cloudformation_stack_id} > 20",
+              id: 1234567,
+              last_triggered_ts: null,
+              name: "Increased Cost",
+              tags: [
+                "service:plugin-demo-ts",
+                "created_by:dd_sls_plugin",
+                "serverless_monitor_type:single_function",
+                "aws_cloudformation_stack-id:cloudformation_stack_id",
+                "serverless_monitor_id:increased_cost",
+                "env:dev",
+              ],
+              org_id: 1234567,
+              priority: null,
+              overall_state_modified: 1234567,
+              restricted_roles: [],
+              type: "query alert",
+            },
           ],
-          org_id: 1234567,
-          priority: null,
-          overall_state_modified: 1234567,
-          restricted_roles: [],
-          type: "query alert",
-        }],
-      }),
-    }).mockReturnValue({
-      status: 200,
-      json: () => ({
-        metadata: { total_count: 2, page: 1, per_page: 1, page_count: 2 },
-        monitors: [{
-          status: "No Data",
-          scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
-          classification: "metric",
-          creator: {
-            handle: "datadog@datadoghq.com",
-            id: 1234567,
-            name: "H Jiang",
-          },
-          metrics: ["aws.lambda.errors"],
-          notifications: [],
-          muted_until_ts: null,
-          query:
-            "sum(last_5m):sum:aws.lambda.errors{functionname:myFunction}.as_count() > 0.20",
-          id: 1234568,
-          last_triggered_ts: null,
-          name: "myFunction High Errors",
-          tags: [
-            "service:plugin-demo-ts",
-            "created_by:dd_sls_plugin",
-            "serverless_monitor_type:single_function",
-            "aws_cloudformation_stack-id:cloudformation_stack_id",
-            "serverless_monitor_id:myFunction_high_errors",
-            "env:dev",
+        }),
+      })
+      .mockReturnValue({
+        status: 200,
+        json: () => ({
+          metadata: { total_count: 2, page: 1, per_page: 1, page_count: 2 },
+          monitors: [
+            {
+              status: "No Data",
+              scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
+              classification: "metric",
+              creator: {
+                handle: "datadog@datadoghq.com",
+                id: 1234567,
+                name: "H Jiang",
+              },
+              metrics: ["aws.lambda.errors"],
+              notifications: [],
+              muted_until_ts: null,
+              query: "sum(last_5m):sum:aws.lambda.errors{functionname:myFunction}.as_count() > 0.20",
+              id: 1234568,
+              last_triggered_ts: null,
+              name: "myFunction High Errors",
+              tags: [
+                "service:plugin-demo-ts",
+                "created_by:dd_sls_plugin",
+                "serverless_monitor_type:single_function",
+                "aws_cloudformation_stack-id:cloudformation_stack_id",
+                "serverless_monitor_id:myFunction_high_errors",
+                "env:dev",
+              ],
+              org_id: 1234567,
+              priority: null,
+              overall_state_modified: 1234567,
+              restricted_roles: [],
+              type: "query alert",
+            },
           ],
-          org_id: 1234567,
-          priority: null,
-          overall_state_modified: 1234567,
-          restricted_roles: [],
-          type: "query alert",
-        }],
-      }),
-    });
+        }),
+      });
     const response = await searchMonitors("datadoghq.com", "queryTag", "apikey", "appkey");
     expect(fetchMock.mock.calls).toHaveLength(2);
     expect(response[0]).toEqual({
@@ -355,8 +362,7 @@ describe("searchMonitor", () => {
       metrics: ["aws.lambda.errors"],
       notifications: [],
       muted_until_ts: null,
-      query:
-        "sum(last_5m):sum:aws.lambda.errors{functionname:myFunction}.as_count() > 0.20",
+      query: "sum(last_5m):sum:aws.lambda.errors{functionname:myFunction}.as_count() > 0.20",
       id: 1234568,
       last_triggered_ts: null,
       name: "myFunction High Errors",

--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -169,7 +169,8 @@ describe("searchMonitor", () => {
     (fetch as unknown as jest.Mock).mockReturnValue({
       status: 200,
       json: () => ({
-        monitors: {
+        metadata: { total_count: 3, page: 0, per_page: 30, page_count: 1 },
+        monitors: [{
           status: "No Data",
           scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
           classification: "metric",
@@ -199,11 +200,11 @@ describe("searchMonitor", () => {
           overall_state_modified: 1234567,
           restricted_roles: [],
           type: "query alert",
-        },
+        }],
       }),
     });
     const response = await searchMonitors("datadoghq.com", "queryTag", "apikey", "appkey");
-    expect(response).toEqual({
+    expect(response[0]).toEqual({
       status: "No Data",
       scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
       classification: "metric",
@@ -226,6 +227,145 @@ describe("searchMonitor", () => {
         "serverless_monitor_type:single_function",
         "aws_cloudformation_stack-id:cloudformation_stack_id",
         "serverless_monitor_id:increased_cost",
+        "env:dev",
+      ],
+      org_id: 1234567,
+      priority: null,
+      overall_state_modified: 1234567,
+      restricted_roles: [],
+      type: "query alert",
+    });
+  });
+  it("returns multiple pages of monitor data", async () => {
+    const fetchMock = (fetch as unknown as jest.Mock).mockReturnValueOnce({
+      status: 200,
+      json: () => ({
+        metadata: { total_count: 2, page: 0, per_page: 1, page_count: 2 },
+        monitors: [{
+          status: "No Data",
+          scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
+          classification: "metric",
+          creator: {
+            handle: "datadog@datadoghq.com",
+            id: 1234567,
+            name: "H Jiang",
+          },
+          metrics: ["aws.lambda.enhanced.estimated_cost"],
+          notifications: [],
+          muted_until_ts: null,
+          query:
+            "pct_change(avg(last_5m),last_5m):avg:aws.lambda.enhanced.estimated_cost{aws_cloudformation_stack-id:cloudformation_stack_id} > 20",
+          id: 1234567,
+          last_triggered_ts: null,
+          name: "Increased Cost",
+          tags: [
+            "service:plugin-demo-ts",
+            "created_by:dd_sls_plugin",
+            "serverless_monitor_type:single_function",
+            "aws_cloudformation_stack-id:cloudformation_stack_id",
+            "serverless_monitor_id:increased_cost",
+            "env:dev",
+          ],
+          org_id: 1234567,
+          priority: null,
+          overall_state_modified: 1234567,
+          restricted_roles: [],
+          type: "query alert",
+        }],
+      }),
+    }).mockReturnValue({
+      status: 200,
+      json: () => ({
+        metadata: { total_count: 2, page: 1, per_page: 1, page_count: 2 },
+        monitors: [{
+          status: "No Data",
+          scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
+          classification: "metric",
+          creator: {
+            handle: "datadog@datadoghq.com",
+            id: 1234567,
+            name: "H Jiang",
+          },
+          metrics: ["aws.lambda.errors"],
+          notifications: [],
+          muted_until_ts: null,
+          query:
+            "sum(last_5m):sum:aws.lambda.errors{functionname:myFunction}.as_count() > 0.20",
+          id: 1234568,
+          last_triggered_ts: null,
+          name: "myFunction High Errors",
+          tags: [
+            "service:plugin-demo-ts",
+            "created_by:dd_sls_plugin",
+            "serverless_monitor_type:single_function",
+            "aws_cloudformation_stack-id:cloudformation_stack_id",
+            "serverless_monitor_id:myFunction_high_errors",
+            "env:dev",
+          ],
+          org_id: 1234567,
+          priority: null,
+          overall_state_modified: 1234567,
+          restricted_roles: [],
+          type: "query alert",
+        }],
+      }),
+    });
+    const response = await searchMonitors("datadoghq.com", "queryTag", "apikey", "appkey");
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    expect(response[0]).toEqual({
+      status: "No Data",
+      scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
+      classification: "metric",
+      creator: {
+        handle: "datadog@datadoghq.com",
+        id: 1234567,
+        name: "H Jiang",
+      },
+      metrics: ["aws.lambda.enhanced.estimated_cost"],
+      notifications: [],
+      muted_until_ts: null,
+      query:
+        "pct_change(avg(last_5m),last_5m):avg:aws.lambda.enhanced.estimated_cost{aws_cloudformation_stack-id:cloudformation_stack_id} > 20",
+      id: 1234567,
+      last_triggered_ts: null,
+      name: "Increased Cost",
+      tags: [
+        "service:plugin-demo-ts",
+        "created_by:dd_sls_plugin",
+        "serverless_monitor_type:single_function",
+        "aws_cloudformation_stack-id:cloudformation_stack_id",
+        "serverless_monitor_id:increased_cost",
+        "env:dev",
+      ],
+      org_id: 1234567,
+      priority: null,
+      overall_state_modified: 1234567,
+      restricted_roles: [],
+      type: "query alert",
+    });
+    expect(response[1]).toEqual({
+      status: "No Data",
+      scopes: ["aws_cloudformation_stack-id:cloudformation_stack_id"],
+      classification: "metric",
+      creator: {
+        handle: "datadog@datadoghq.com",
+        id: 1234567,
+        name: "H Jiang",
+      },
+      metrics: ["aws.lambda.errors"],
+      notifications: [],
+      muted_until_ts: null,
+      query:
+        "sum(last_5m):sum:aws.lambda.errors{functionname:myFunction}.as_count() > 0.20",
+      id: 1234568,
+      last_triggered_ts: null,
+      name: "myFunction High Errors",
+      tags: [
+        "service:plugin-demo-ts",
+        "created_by:dd_sls_plugin",
+        "serverless_monitor_type:single_function",
+        "aws_cloudformation_stack-id:cloudformation_stack_id",
+        "serverless_monitor_id:myFunction_high_errors",
         "env:dev",
       ],
       org_id: 1234567,

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -72,7 +72,7 @@ export async function deleteMonitor(site: string, monitorId: number, monitorsApi
 export async function searchMonitors(site: string, queryTag: string, monitorsApiKey: string, monitorsAppKey: string) {
   let monitors: QueriedMonitor[] = [];
   let page = 0;
-  let page_count = 1;
+  let pageCount = 1;
   do {
     const query = `tag:"${queryTag}"`;
     const response: Response = await fetch(`https://api.${site}/api/v1/monitor/search?query=${query}&page=${page}`, {
@@ -91,9 +91,9 @@ export async function searchMonitors(site: string, queryTag: string, monitorsApi
     const json = await response.json();
     monitors = monitors.concat(json.monitors);
 
-    page_count = json.metadata.page_count;
+    pageCount = json.metadata.page_count;
     page += 1;
-  } while (page < page_count);
+  } while (page < pageCount);
 
   return monitors;
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This pr adds pagination to the seachMonitors method.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

We encountered an error where a serverless stack with 33 monitors would always return a 400 error while deploying monitors unless we first manually deleted all monitors associated with the stack.  Upon investigation I found that the searchMonitors method only fetches 30 monitors (the page size default for the search api), thus ensuring that there will always be 3 monitors that "exist" but are not part of the [serverlessMonitorIdByMonitorId](https://github.com/DataDog/serverless-plugin-datadog/blob/master/src/monitors.ts#L163) map.  DD will attempt to create instead of update these monitors resulting in a 400 error..

### Testing Guidelines

I added an additional test case which will return metadata stating that more than 1 page of monitors exists, this will trigger the searchMonitors method to iterate until it retrieves all the monitors.  No existing monitors are failing. I updated one of the existing test cases to return and array of monitors instead of a monitor object, this is what's expected base on reading the code and experiments with the api.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
