### PR TITLE
feat: Add support for Node 20

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -113,6 +113,12 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello18-x"
       }
     },
+    "JavascriptHello20DashxLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello20-x"
+      }
+    },
     "DotnetHello6LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -594,6 +600,55 @@
         "JavascriptHello18DashxLogGroup"
       ]
     },
+    "JavascriptHello20DashxLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+        "Runtime": "nodejs20.x",
+        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello20-x",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Tags": [
+          {
+            "Key": "dd_sls_plugin",
+            "Value": "vX.XX.X"
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "DD_API_KEY": 1234,
+            "DD_SITE": "datadoghq.com",
+            "DD_LOG_LEVEL": "info",
+            "DD_TRACE_ENABLED": true,
+            "DD_MERGE_XRAY_TRACES": false,
+            "DD_LOGS_INJECTION": false,
+            "DD_SERVERLESS_LOGS_ENABLED": true,
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
+            "DD_LAMBDA_HANDLER": "js_handler.hello"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        },
+        "Layers": [
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+        ]
+      },
+      "DependsOn": [
+        "JavascriptHello20DashxLogGroup"
+      ]
+    },
     "DotnetHello6LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1006,6 +1061,16 @@
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello18DashxLambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
+    },
+    "JavascriptHello20DashxLambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "JavascriptHello20DashxLambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1882,6 +1947,15 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello18DashxLambdaFunctionQualifiedArn"
+      }
+    },
+    "JavascriptHello20DashxLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "JavascriptHello20DashxLambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello20DashxLambdaFunctionQualifiedArn"
       }
     },
     "DotnetHello6LambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -113,6 +113,12 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello18-x"
       }
     },
+    "JavascriptHello20DashxLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello20-x"
+      }
+    },
     "ExcludeThisLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -638,6 +644,57 @@
         "JavascriptHello18DashxLogGroup"
       ]
     },
+    "JavascriptHello20DashxLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+        "Runtime": "nodejs20.x",
+        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello20-x",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Tags": [
+          {
+            "Key": "dd_sls_plugin",
+            "Value": "vX.XX.X"
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "DD_API_KEY": 1234,
+            "DD_SITE": "datadoghq.com",
+            "DD_TRACE_ENABLED": true,
+            "DD_MERGE_XRAY_TRACES": false,
+            "DD_LOGS_INJECTION": false,
+            "DD_SERVERLESS_LOGS_ENABLED": true,
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev",
+            "DD_LAMBDA_HANDLER": "js_handler.hello"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        },
+        "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+        ]
+      },
+      "DependsOn": [
+        "JavascriptHello20DashxLogGroup"
+      ]
+    },
     "ExcludeThisLambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1146,6 +1203,16 @@
         "CodeSha256": "XXXX"
       }
     },
+    "JavascriptHello20DashxLambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "JavascriptHello20DashxLambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
+    },
     "ExcludeThisLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -1354,6 +1421,15 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello18DashxLambdaFunctionQualifiedArn"
+      }
+    },
+    "JavascriptHello20DashxLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "JavascriptHello20DashxLambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello20DashxLambdaFunctionQualifiedArn"
       }
     },
     "ExcludeThisLambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -113,6 +113,12 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello18-x"
       }
     },
+    "JavascriptHello20DashxLogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello20-x"
+      }
+    },
     "ExcludeThisLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -323,6 +329,16 @@
         "FilterPattern": "",
         "LogGroupName": {
           "Ref": "JavascriptHello18DashxLogGroup"
+        }
+      }
+    },
+    "JavascriptHello20DashxLogGroupSubscription": {
+      "Type": "AWS::Logs::SubscriptionFilter",
+      "Properties": {
+        "DestinationArn": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
+        "FilterPattern": "",
+        "LogGroupName": {
+          "Ref": "JavascriptHello20DashxLogGroup"
         }
       }
     },
@@ -885,6 +901,58 @@
         "JavascriptHello18DashxLogGroup"
       ]
     },
+    "JavascriptHello20DashxLambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+        "Runtime": "nodejs20.x",
+        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello20-x",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Tags": [
+          {
+            "Key": "dd_sls_plugin",
+            "Value": "vX.XX.X"
+          },
+          {
+            "Key": "service",
+            "Value": "dd-sls-plugin-integration-test"
+          },
+          {
+            "Key": "env",
+            "Value": "dev"
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "DD_SITE": "datadoghq.com",
+            "DD_LOG_LEVEL": "info",
+            "DD_FLUSH_TO_LOG": true,
+            "DD_TRACE_ENABLED": true,
+            "DD_MERGE_XRAY_TRACES": false,
+            "DD_LOGS_INJECTION": true,
+            "DD_SERVERLESS_LOGS_ENABLED": true,
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "DD_LAMBDA_HANDLER": "js_handler.hello"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "JavascriptHello20DashxLogGroup"
+      ]
+    },
     "ExcludeThisLambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1368,6 +1436,16 @@
       "Properties": {
         "FunctionName": {
           "Ref": "JavascriptHello18DashxLambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
+    },
+    "JavascriptHello20DashxLambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "JavascriptHello20DashxLambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -2605,6 +2683,15 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello18DashxLambdaFunctionQualifiedArn"
+      }
+    },
+    "JavascriptHello20DashxLambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "JavascriptHello20DashxLambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello20DashxLambdaFunctionQualifiedArn"
       }
     },
     "ExcludeThisLambdaFunctionQualifiedArn": {

--- a/integration_tests/serverless-extension-apigateway.yml
+++ b/integration_tests/serverless-extension-apigateway.yml
@@ -60,6 +60,9 @@ functions:
   JavascriptHello18-x:
     handler: js_handler.hello
     runtime: nodejs18.x
+  JavascriptHello20-x:
+    handler: js_handler.hello
+    runtime: nodejs20.x
   DotnetHello6:
     handler: dotnet_handler.hello
     runtime: dotnet6

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -44,6 +44,9 @@ functions:
   JavascriptHello18-x:
     handler: js_handler.hello
     runtime: nodejs18.x
+  JavascriptHello20-x:
+    handler: js_handler.hello
+    runtime: nodejs20.x
   ExcludeThis:
     handler: js_handler.hello
     runtime: nodejs14.x

--- a/integration_tests/serverless-forwarder.yml
+++ b/integration_tests/serverless-forwarder.yml
@@ -66,6 +66,9 @@ functions:
   JavascriptHello18-x:
     handler: js_handler.hello
     runtime: nodejs18.x
+  JavascriptHello20-x:
+    handler: js_handler.hello
+    runtime: nodejs20.x
   ExcludeThis:
     handler: js_handler.hello
     runtime: nodejs14.x

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Ruby2-7" "Datadog-Ruby2-7-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "ruby2.7" "ruby2.7-arm" "ruby3.2" "ruby3.2-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
+LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Ruby2-7" "Datadog-Ruby2-7-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
+JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "nodejs20.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "ruby2.7" "ruby2.7-arm" "ruby3.2" "ruby3.2-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 FILE_NAME="src/layers.json"

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -39,13 +39,14 @@ function createMockService(
 }
 
 describe("findHandlers", () => {
-  it("finds all node and python layers with matching layers", () => {
+  it("finds all runtimes with matching layers", () => {
     const mockService = createMockService("us-east-1", {
       "go-function": { handler: "myfile.handler", runtime: "go1.10" },
       "node12-function": { handler: "myfile.handler", runtime: "nodejs12.x" },
       "node14-function": { handler: "myfile.handler", runtime: "nodejs14.x" },
       "node16-function": { handler: "myfile.handler", runtime: "nodejs16.x" },
       "node18-function": { handler: "myfile.handler", runtime: "nodejs18.x" },
+      "node20-function": { handler: "myfile.handler", runtime: "nodejs20.x" },
       "python37-function": { handler: "myfile.handler", runtime: "python3.7" },
       "python38-function": { handler: "myfile.handler", runtime: "python3.8" },
       "python39-function": { handler: "myfile.handler", runtime: "python3.9" },
@@ -93,6 +94,12 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "nodejs18.x" },
         type: RuntimeType.NODE,
         runtime: "nodejs18.x",
+      },
+      {
+        name: "node20-function",
+        handler: { handler: "myfile.handler", runtime: "nodejs20.x" },
+        type: RuntimeType.NODE,
+        runtime: "nodejs20.x",
       },
       {
         name: "python37-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -56,6 +56,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "nodejs14.x": RuntimeType.NODE,
   "nodejs16.x": RuntimeType.NODE,
   "nodejs18.x": RuntimeType.NODE,
+  "nodejs20.x": RuntimeType.NODE,
   "python3.7": RuntimeType.PYTHON,
   "python3.8": RuntimeType.PYTHON,
   "python3.9": RuntimeType.PYTHON,
@@ -89,6 +90,7 @@ export const ARM_RUNTIME_KEYS: { [key: string]: string } = {
   "nodejs14.x": "nodejs14.x",
   "nodejs16.x": "nodejs16.x",
   "nodejs18.x": "nodejs18.x",
+  "nodejs20.x": "nodejs20.x",
   // The same Java layer works for both x86 and ARM
   java: "java",
 };


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for Node 20 as it's [available](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) for AWS Lambda.

### Motivation

It's widely available, and the latest layer ([v100](https://github.com/DataDog/datadog-lambda-js/releases/tag/v7.100.0)) has already been released with support for it.

Also #448 

### Testing Guidelines

- [x] Unit tests
- [x] Integration tests 

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
