### PR TITLE
Add java21 to the runtime list

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -66,6 +66,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   dotnet6: RuntimeType.DOTNET,
   java11: RuntimeType.JAVA,
   java17: RuntimeType.JAVA,
+  java21: RuntimeType.JAVA,
   "java8.al2": RuntimeType.JAVA,
   java8: RuntimeType.JAVA,
   "provided.al2": RuntimeType.CUSTOM,


### PR DESCRIPTION
### What does this PR do?

Adds java 21 to the supported runtime list 

### Motivation

Java21 is out and is supported on AWS Lambda. java-dd-trace also supports java 21 (https://github.com/DataDog/dd-trace-java/issues/5999), thus no reason not to support it in the plugin as well

### Types of changes

- [x] New feature
