### PR TITLE
handle empty stepfunctions obj in inspectAndRecommendStepFunctionsInstrumentation()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ module.exports = class ServerlessPlugin {
           inspectAndRecommendStepFunctionsInstrumentation(this.serverless);
         } catch (error) {
           this.serverless.cli.log(
-            `Error raise when inspecting if there are any uninstrumented Step Functions state machines. Error: ${error}`,
+            `Error raised when inspecting if there are any uninstrumented Step Functions state machines. Error: ${error}`,
           );
         }
       }

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -93,7 +93,7 @@ export function updateDefinitionString(
 }
 
 export function inspectAndRecommendStepFunctionsInstrumentation(serverless: Serverless) {
-  const stepFunctions = Object.values((serverless.service as any).stepFunctions.stateMachines);
+  const stepFunctions = Object.values((serverless.service as any).stepFunctions?.stateMachines || {});
   if (stepFunctions.length !== 0) {
     serverless.cli.log(
       `Uninstrumented Step Functions detected in your serverless.yml file. If you would like to see Step Functions traces, please see details of 'enableStepFunctionsTracing' and 'mergeStepFunctionAndLambdaTraces' variables in the README (https://github.com/DataDog/serverless-plugin-datadog/)`,


### PR DESCRIPTION
https://github.com/DataDog/serverless-plugin-datadog/pull/426

When the serverless.yaml file doesn't have step functions defined, this error message will keep showing up for all customers. This PR updates the logic of printing such error message.