### PR TITLE
chore: Deprecate Ruby 2.7 instrumentation

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -149,12 +149,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-providedHello"
       }
     },
-    "RubyHello27LogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-RubyHello27"
-      }
-    },
     "RubyHello32LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -898,55 +892,6 @@
         "ProvidedHelloLogGroup"
       ]
     },
-    "RubyHello27LambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "rb_handler.hello",
-        "Runtime": "ruby2.7",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-RubyHello27",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_LOG_LEVEL": "info",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": false,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Ruby2-7:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "RubyHello27LogGroup"
-      ]
-    },
     "RubyHello32LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1122,16 +1067,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "ProvidedHelloLambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
-    "RubyHello27LambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "RubyHello27LambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -2002,15 +1937,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-ProvidedHelloLambdaFunctionQualifiedArn"
-      }
-    },
-    "RubyHello27LambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "RubyHello27LambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-RubyHello27LambdaFunctionQualifiedArn"
       }
     },
     "RubyHello32LambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -161,12 +161,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-providedHello"
       }
     },
-    "RubyHello27LogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-RubyHello27"
-      }
-    },
     "RubyHello32LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -1042,57 +1036,6 @@
         "ProvidedHelloLogGroup"
       ]
     },
-    "RubyHello27LambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "rb_handler.hello",
-        "Runtime": "ruby2.7",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-RubyHello27",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": false,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          {
-            "Ref": "ProviderLevelLayerLambdaLayer"
-          },
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Ruby2-7:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "RubyHello27LogGroup"
-      ]
-    },
     "RubyHello32LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1280,16 +1223,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "ProvidedHelloLambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
-    "RubyHello27LambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "RubyHello27LambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1494,15 +1427,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-ProvidedHelloLambdaFunctionQualifiedArn"
-      }
-    },
-    "RubyHello27LambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "RubyHello27LambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-RubyHello27LambdaFunctionQualifiedArn"
       }
     },
     "RubyHello32LambdaFunctionQualifiedArn": {

--- a/integration_tests/serverless-extension-apigateway.yml
+++ b/integration_tests/serverless-extension-apigateway.yml
@@ -78,9 +78,6 @@ functions:
   providedHello:
     handler: provided_handler.hello
     runtime: provided
-  RubyHello27:
-    handler: rb_handler.hello
-    runtime: ruby2.7
   RubyHello32:
     handler: rb_handler.hello
     runtime: ruby3.2

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -69,9 +69,6 @@ functions:
   providedHello:
     handler: provided_handler.hello
     runtime: provided
-  RubyHello27:
-    handler: rb_handler.hello
-    runtime: ruby2.7
   RubyHello32:
     handler: rb_handler.hello
     runtime: ruby3.2

--- a/integration_tests/serverless-forwarder.yml
+++ b/integration_tests/serverless-forwarder.yml
@@ -90,9 +90,6 @@ functions:
   providedHello:
     handler: provided_handler.hello
     runtime: provided
-  RubyHello27:
-    handler: rb_handler.hello
-    runtime: ruby2.7
   RubyHello32:
     handler: rb_handler.hello
     runtime: ruby3.2

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Ruby2-7" "Datadog-Ruby2-7-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "nodejs20.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "ruby2.7" "ruby2.7-arm" "ruby3.2" "ruby3.2-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
+LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
+JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "nodejs20.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "ruby3.2" "ruby3.2-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 FILE_NAME="src/layers.json"

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -53,7 +53,6 @@ describe("findHandlers", () => {
       "python310-function": { handler: "myfile.handler", runtime: "python3.10" },
       "python311-function": { handler: "myfile.handler", runtime: "python3.11" },
       "python312-function": { handler: "myfile.handler", runtime: "python3.12" },
-      "ruby27-function": { handler: "myfile.handler", runtime: "ruby2.7" },
       "ruby32-function": { handler: "myfile.handler", runtime: "ruby3.2" },
       "java8-function": { handler: "myfile.handler", runtime: "java8" },
       "java8.al2-function": { handler: "myfile.handler", runtime: "java8.al2" },
@@ -138,12 +137,6 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "python3.12" },
         type: RuntimeType.PYTHON,
         runtime: "python3.12",
-      },
-      {
-        name: "ruby27-function",
-        handler: { handler: "myfile.handler", runtime: "ruby2.7" },
-        type: RuntimeType.RUBY,
-        runtime: "ruby2.7",
       },
       {
         name: "ruby32-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -72,7 +72,6 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   java8: RuntimeType.JAVA,
   "provided.al2": RuntimeType.CUSTOM,
   provided: RuntimeType.CUSTOM,
-  "ruby2.7": RuntimeType.RUBY,
   "ruby3.2": RuntimeType.RUBY,
   "go1.x": RuntimeType.GO,
 };
@@ -84,7 +83,6 @@ export const ARM_RUNTIME_KEYS: { [key: string]: string } = {
   "python3.10": "python3.10-arm",
   "python3.11": "python3.11-arm",
   "python3.12": "python3.12-arm",
-  "ruby2.7": "ruby2.7-arm",
   "ruby3.2": "ruby3.2-arm",
   extension: "extension-arm",
   dotnet: "dotnet-arm",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Deprecates Ruby 2.7 instrumentation.

### Motivation

Ruby 2.7 went in deprecation phase 2 as per [AWS Lambda Runtime Deprecation Policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

### Testing Guidelines

n/a

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
