### PR TITLE
chore: Deprecate .NET Core 3.1 instrumentation

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -125,12 +125,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello6"
       }
     },
-    "DotnetcoreHello31LogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetcoreHello31"
-      }
-    },
     "JavaHello8LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -700,56 +694,6 @@
         "DotnetHello6LogGroup"
       ]
     },
-    "DotnetcoreHello31LambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "dotnet_handler.hello",
-        "Runtime": "dotnetcore3.1",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-DotnetcoreHello31",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_LOG_LEVEL": "info",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": false,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "DotnetcoreHello31LogGroup"
-      ]
-    },
     "JavaHello8LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1082,16 +1026,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "DotnetHello6LambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
-    "DotnetcoreHello31LambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "DotnetcoreHello31LambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1966,15 +1900,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello6LambdaFunctionQualifiedArn"
-      }
-    },
-    "DotnetcoreHello31LambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "DotnetcoreHello31LambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetcoreHello31LambdaFunctionQualifiedArn"
       }
     },
     "JavaHello8LambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -131,12 +131,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello6"
       }
     },
-    "DotnetcoreHello31LogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetcoreHello31"
-      }
-    },
     "DotnetArmHello6LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -781,58 +775,6 @@
         "DotnetHello6LogGroup"
       ]
     },
-    "DotnetcoreHello31LambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "dotnet_handler.hello",
-        "Runtime": "dotnetcore3.1",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-DotnetcoreHello31",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": false,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          {
-            "Ref": "ProviderLevelLayerLambdaLayer"
-          },
-          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "DotnetcoreHello31LogGroup"
-      ]
-    },
     "DotnetArmHello6LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1234,16 +1176,6 @@
         "CodeSha256": "XXXX"
       }
     },
-    "DotnetcoreHello31LambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "DotnetcoreHello31LambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
     "DotnetArmHello6LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -1449,15 +1381,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello6LambdaFunctionQualifiedArn"
-      }
-    },
-    "DotnetcoreHello31LambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "DotnetcoreHello31LambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetcoreHello31LambdaFunctionQualifiedArn"
       }
     },
     "DotnetArmHello6LambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -137,12 +137,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello6"
       }
     },
-    "DotnetcoreHello31LogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetcoreHello31"
-      }
-    },
     "JavaHello8LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -349,16 +343,6 @@
         "FilterPattern": "",
         "LogGroupName": {
           "Ref": "DotnetHello6LogGroup"
-        }
-      }
-    },
-    "DotnetcoreHello31LogGroupSubscription": {
-      "Type": "AWS::Logs::SubscriptionFilter",
-      "Properties": {
-        "DestinationArn": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
-        "FilterPattern": "",
-        "LogGroupName": {
-          "Ref": "DotnetcoreHello31LogGroup"
         }
       }
     },
@@ -1058,58 +1042,6 @@
         "DotnetHello6LogGroup"
       ]
     },
-    "DotnetcoreHello31LambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "dotnet_handler.hello",
-        "Runtime": "dotnetcore3.1",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-DotnetcoreHello31",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_SITE": "datadoghq.com",
-            "DD_LOG_LEVEL": "info",
-            "DD_FLUSH_TO_LOG": true,
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": true,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        }
-      },
-      "DependsOn": [
-        "DotnetcoreHello31LogGroup"
-      ]
-    },
     "JavaHello8LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1479,16 +1411,6 @@
       "Properties": {
         "FunctionName": {
           "Ref": "DotnetHello6LambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
-    "DotnetcoreHello31LambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "DotnetcoreHello31LambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -2722,15 +2644,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello6LambdaFunctionQualifiedArn"
-      }
-    },
-    "DotnetcoreHello31LambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "DotnetcoreHello31LambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetcoreHello31LambdaFunctionQualifiedArn"
       }
     },
     "JavaHello8LambdaFunctionQualifiedArn": {

--- a/integration_tests/serverless-extension-apigateway.yml
+++ b/integration_tests/serverless-extension-apigateway.yml
@@ -66,9 +66,6 @@ functions:
   DotnetHello6:
     handler: dotnet_handler.hello
     runtime: dotnet6
-  DotnetcoreHello31:
-    handler: dotnet_handler.hello
-    runtime: dotnetcore3.1
   JavaHello8:
     handler: java_handler.hello
     runtime: java8

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -53,9 +53,6 @@ functions:
   DotnetHello6:
     handler: dotnet_handler.hello
     runtime: dotnet6
-  DotnetcoreHello31:
-    handler: dotnet_handler.hello
-    runtime: dotnetcore3.1
   DotnetArmHello6:
     handler: dotnet_handler.hello
     runtime: dotnet6

--- a/integration_tests/serverless-forwarder.yml
+++ b/integration_tests/serverless-forwarder.yml
@@ -78,9 +78,6 @@ functions:
   DotnetHello6:
     handler: dotnet_handler.hello
     runtime: dotnet6
-  DotnetcoreHello31:
-    handler: dotnet_handler.hello
-    runtime: dotnetcore3.1
   JavaHello8:
     handler: java_handler.hello
     runtime: java8

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -61,7 +61,6 @@ describe("findHandlers", () => {
       "java17-function": { handler: "myfile.handler", runtime: "java17" },
       "java21-function": { handler: "myfile.handler", runtime: "java21" },
       "dotnet6-function": { handler: "myfile.handler", runtime: "dotnet6" },
-      "dotnetcore3.1-function": { handler: "myfile.handler", runtime: "dotnetcore3.1" },
       "provided-function": { handler: "myfile.handler", runtime: "provided" },
     });
 
@@ -186,12 +185,6 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "dotnet6" },
         type: RuntimeType.DOTNET,
         runtime: "dotnet6",
-      },
-      {
-        name: "dotnetcore3.1-function",
-        handler: { handler: "myfile.handler", runtime: "dotnetcore3.1" },
-        type: RuntimeType.DOTNET,
-        runtime: "dotnetcore3.1",
       },
       {
         name: "provided-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -63,7 +63,6 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.10": RuntimeType.PYTHON,
   "python3.11": RuntimeType.PYTHON,
   "python3.12": RuntimeType.PYTHON,
-  "dotnetcore3.1": RuntimeType.DOTNET,
   dotnet6: RuntimeType.DOTNET,
   java11: RuntimeType.JAVA,
   java17: RuntimeType.JAVA,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Deprecates .NET Core 3.1 instrumentation.

### Motivation

.NET Core 3.1 went in deprecation phase 2 as per [AWS Lambda Runtime Deprecation Policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

### Testing Guidelines

n/a

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
