### PR TITLE
chore: Deprecate Node.js 12.x instrumentation

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -89,12 +89,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-PythonHello39"
       }
     },
-    "JavascriptHello12DashxLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello12-x"
-      }
-    },
     "JavascriptHello14DashxLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -398,56 +392,6 @@
       },
       "DependsOn": [
         "PythonHello39LogGroup"
-      ]
-    },
-    "JavascriptHello12DashxLambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
-        "Runtime": "nodejs12.x",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello12-x",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_LOG_LEVEL": "info",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": false,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev",
-            "DD_LAMBDA_HANDLER": "js_handler.hello"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "JavascriptHello12DashxLogGroup"
       ]
     },
     "JavascriptHello14DashxLambdaFunction": {
@@ -1026,16 +970,6 @@
         "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello12DashxLambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "JavascriptHello12DashxLambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
     "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -1262,7 +1196,7 @@
                 ":lambda:path/2015-03-31/functions/",
                 {
                   "Fn::GetAtt": [
-                    "JavascriptHello12DashxLambdaFunction",
+                    "JavascriptHello14DashxLambdaFunction",
                     "Arn"
                   ]
                 },
@@ -1274,7 +1208,7 @@
         "MethodResponses": []
       },
       "DependsOn": [
-        "JavascriptHello12DashxLambdaPermissionApiGateway"
+        "JavascriptHello14DashxLambdaPermissionApiGateway"
       ]
     },
     "ApiGatewayDeploymentxxxx": {
@@ -1327,12 +1261,12 @@
         }
       }
     },
-    "JavascriptHello12DashxLambdaPermissionApiGateway": {
+    "JavascriptHello14DashxLambdaPermissionApiGateway": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1532,7 +1466,7 @@
         }
       }
     },
-    "JavascriptHello12DashxWebsocketsIntegration": {
+    "JavascriptHello14DashxWebsocketsIntegration": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -1554,7 +1488,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "JavascriptHello12DashxLambdaFunction",
+                  "JavascriptHello14DashxLambdaFunction",
                   "Arn"
                 ]
               },
@@ -1581,16 +1515,16 @@
         "Principal": "apigateway.amazonaws.com"
       }
     },
-    "JavascriptHello12DashxLambdaPermissionWebsockets": {
+    "JavascriptHello14DashxLambdaPermissionWebsockets": {
       "Type": "AWS::Lambda::Permission",
       "DependsOn": [
         "WebsocketsApi",
-        "JavascriptHello12DashxLambdaFunction"
+        "JavascriptHello14DashxLambdaFunction"
       ],
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1612,7 +1546,7 @@
             [
               "integrations",
               {
-                "Ref": "JavascriptHello12DashxWebsocketsIntegration"
+                "Ref": "JavascriptHello14DashxWebsocketsIntegration"
               }
             ]
           ]
@@ -1638,7 +1572,7 @@
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.eventType $context.routeKey $context.connectionId\" $context.requestId"
         },
         "DeploymentId": {
-          "Ref": "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4"
+          "Ref": "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI"
         }
       }
     },
@@ -1648,7 +1582,7 @@
         "LogGroupName": "/aws/websocket/dd-sls-plugin-integration-test-dev"
       }
     },
-    "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4": {
+    "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI": {
       "Type": "AWS::ApiGatewayV2::Deployment",
       "DependsOn": [
         "SconnectWebsocketsRoute",
@@ -1772,12 +1706,12 @@
       },
       "DependsOn": "HttpApiIntegrationPythonHello39"
     },
-    "JavascriptHello12DashxLambdaPermissionHttpApi": {
+    "JavascriptHello14DashxLambdaPermissionHttpApi": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1809,7 +1743,7 @@
         }
       }
     },
-    "HttpApiIntegrationJavascriptHello12Dashx": {
+    "HttpApiIntegrationJavascriptHello14Dashx": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -1818,7 +1752,7 @@
         "IntegrationType": "AWS_PROXY",
         "IntegrationUri": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -1839,13 +1773,13 @@
             [
               "integrations",
               {
-                "Ref": "HttpApiIntegrationJavascriptHello12Dashx"
+                "Ref": "HttpApiIntegrationJavascriptHello14Dashx"
               }
             ]
           ]
         }
       },
-      "DependsOn": "HttpApiIntegrationJavascriptHello12Dashx"
+      "DependsOn": "HttpApiIntegrationJavascriptHello14Dashx"
     },
     "ApiGatewayLogGroupSubscription": {
       "Type": "AWS::Logs::SubscriptionFilter",
@@ -1912,15 +1846,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-PythonHello39LambdaFunctionQualifiedArn"
-      }
-    },
-    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -89,12 +89,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-PythonHello39"
       }
     },
-    "JavascriptHello12DashxLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello12-x"
-      }
-    },
     "JavascriptHello14DashxLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -263,7 +257,7 @@
         "LayerName": "dd-sls-plugin-integration-test-dev-ProviderLevelLayer",
         "Description": "It's a text file",
         "CompatibleRuntimes": [
-          "nodejs12.x"
+          "nodejs14.x"
         ]
       }
     },
@@ -436,58 +430,6 @@
         "PythonHello39LogGroup"
       ]
     },
-    "JavascriptHello12DashxLambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
-        "Runtime": "nodejs12.x",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello12-x",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_API_KEY": 1234,
-            "DD_SITE": "datadoghq.com",
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": false,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_SERVICE": "dd-sls-plugin-integration-test",
-            "DD_ENV": "dev",
-            "DD_LAMBDA_HANDLER": "js_handler.hello"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          {
-            "Ref": "FunctionLevelLayerLambdaLayer"
-          },
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX",
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
-        ]
-      },
-      "DependsOn": [
-        "JavascriptHello12DashxLogGroup"
-      ]
-    },
     "JavascriptHello14DashxLambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -530,7 +472,7 @@
         },
         "Layers": [
           {
-            "Ref": "ProviderLevelLayerLambdaLayer"
+            "Ref": "FunctionLevelLayerLambdaLayer"
           },
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
           "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
@@ -1174,16 +1116,6 @@
         "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello14DashxLambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "JavascriptHello14DashxLambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
     "JavascriptHello16DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -1304,12 +1236,12 @@
         "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello12DashxLambdaVersionXXXX": {
+    "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
       "Properties": {
         "FunctionName": {
-          "Ref": "JavascriptHello12DashxLambdaFunction"
+          "Ref": "JavascriptHello14DashxLambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1335,7 +1267,7 @@
     },
     "ProviderLevelLayerLambdaLayerHash": {
       "Description": "Current Lambda layer hash",
-      "Value": "ca99f65eb22bc573edd4f9ac2a087d0dd5acc751",
+      "Value": "9fc1163e4a4e81d5019bc0e9d4f63aa54d97576f",
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-ProviderLevelLayerLambdaLayerHash"
       }
@@ -1395,15 +1327,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-PythonHello39LambdaFunctionQualifiedArn"
-      }
-    },
-    "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "JavascriptHello14DashxLambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello14DashxLambdaFunctionQualifiedArn"
       }
     },
     "JavascriptHello16DashxLambdaFunctionQualifiedArn": {
@@ -1514,13 +1437,13 @@
         "Name": "sls-dd-sls-plugin-integration-test-dev-RubyHello32LambdaFunctionQualifiedArn"
       }
     },
-    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
+    "JavascriptHello14DashxLambdaFunctionQualifiedArn": {
       "Description": "Current Lambda function version",
       "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
+        "Ref": "JavascriptHello14DashxLambdaVersionXXXX"
       },
       "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
+        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello14DashxLambdaFunctionQualifiedArn"
       }
     }
   }

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -89,12 +89,6 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-PythonHello39"
       }
     },
-    "JavascriptHello12DashxLogGroup": {
-      "Type": "AWS::Logs::LogGroup",
-      "Properties": {
-        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-JavascriptHello12-x"
-      }
-    },
     "JavascriptHello14DashxLogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -289,16 +283,6 @@
         "FilterPattern": "",
         "LogGroupName": {
           "Ref": "PythonHello39LogGroup"
-        }
-      }
-    },
-    "JavascriptHello12DashxLogGroupSubscription": {
-      "Type": "AWS::Logs::SubscriptionFilter",
-      "Properties": {
-        "DestinationArn": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
-        "FilterPattern": "",
-        "LogGroupName": {
-          "Ref": "JavascriptHello12DashxLogGroup"
         }
       }
     },
@@ -679,61 +663,6 @@
       },
       "DependsOn": [
         "PythonHello39LogGroup"
-      ]
-    },
-    "JavascriptHello12DashxLambdaFunction": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Ref": "ServerlessDeploymentBucket"
-          },
-          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
-        },
-        "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
-        "Runtime": "nodejs12.x",
-        "FunctionName": "dd-sls-plugin-integration-test-dev-JavascriptHello12-x",
-        "MemorySize": 1024,
-        "Timeout": 6,
-        "Tags": [
-          {
-            "Key": "dd_sls_plugin",
-            "Value": "vX.XX.X"
-          },
-          {
-            "Key": "service",
-            "Value": "dd-sls-plugin-integration-test"
-          },
-          {
-            "Key": "env",
-            "Value": "dev"
-          }
-        ],
-        "Environment": {
-          "Variables": {
-            "DD_SITE": "datadoghq.com",
-            "DD_LOG_LEVEL": "info",
-            "DD_FLUSH_TO_LOG": true,
-            "DD_TRACE_ENABLED": true,
-            "DD_MERGE_XRAY_TRACES": false,
-            "DD_LOGS_INJECTION": true,
-            "DD_SERVERLESS_LOGS_ENABLED": true,
-            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
-            "DD_LAMBDA_HANDLER": "js_handler.hello"
-          }
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "IamRoleLambdaExecution",
-            "Arn"
-          ]
-        },
-        "Layers": [
-          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node12-x:XXX"
-        ]
-      },
-      "DependsOn": [
-        "JavascriptHello12DashxLogGroup"
       ]
     },
     "JavascriptHello14DashxLambdaFunction": {
@@ -1403,16 +1332,6 @@
         "CodeSha256": "XXXX"
       }
     },
-    "JavascriptHello12DashxLambdaVersionXXXX": {
-      "Type": "AWS::Lambda::Version",
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "FunctionName": {
-          "Ref": "JavascriptHello12DashxLambdaFunction"
-        },
-        "CodeSha256": "XXXX"
-      }
-    },
     "JavascriptHello14DashxLambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -2014,7 +1933,7 @@
                 ":lambda:path/2015-03-31/functions/",
                 {
                   "Fn::GetAtt": [
-                    "JavascriptHello12DashxLambdaFunction",
+                    "JavascriptHello14DashxLambdaFunction",
                     "Arn"
                   ]
                 },
@@ -2026,7 +1945,7 @@
         "MethodResponses": []
       },
       "DependsOn": [
-        "JavascriptHello12DashxLambdaPermissionApiGateway"
+        "JavascriptHello14DashxLambdaPermissionApiGateway"
       ]
     },
     "ApiGatewayDeploymentxxxx": {
@@ -2079,12 +1998,12 @@
         }
       }
     },
-    "JavascriptHello12DashxLambdaPermissionApiGateway": {
+    "JavascriptHello14DashxLambdaPermissionApiGateway": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2284,7 +2203,7 @@
         }
       }
     },
-    "JavascriptHello12DashxWebsocketsIntegration": {
+    "JavascriptHello14DashxWebsocketsIntegration": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -2306,7 +2225,7 @@
               ":lambda:path/2015-03-31/functions/",
               {
                 "Fn::GetAtt": [
-                  "JavascriptHello12DashxLambdaFunction",
+                  "JavascriptHello14DashxLambdaFunction",
                   "Arn"
                 ]
               },
@@ -2333,16 +2252,16 @@
         "Principal": "apigateway.amazonaws.com"
       }
     },
-    "JavascriptHello12DashxLambdaPermissionWebsockets": {
+    "JavascriptHello14DashxLambdaPermissionWebsockets": {
       "Type": "AWS::Lambda::Permission",
       "DependsOn": [
         "WebsocketsApi",
-        "JavascriptHello12DashxLambdaFunction"
+        "JavascriptHello14DashxLambdaFunction"
       ],
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2364,7 +2283,7 @@
             [
               "integrations",
               {
-                "Ref": "JavascriptHello12DashxWebsocketsIntegration"
+                "Ref": "JavascriptHello14DashxWebsocketsIntegration"
               }
             ]
           ]
@@ -2390,7 +2309,7 @@
           "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.eventType $context.routeKey $context.connectionId\" $context.requestId"
         },
         "DeploymentId": {
-          "Ref": "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4"
+          "Ref": "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI"
         }
       }
     },
@@ -2400,7 +2319,7 @@
         "LogGroupName": "/aws/websocket/dd-sls-plugin-integration-test-dev"
       }
     },
-    "WebsocketsDeploymentlV0zc2iqXFiHxw7QcuYM0WF4fPmXYd3A6RWKSnAzp4": {
+    "WebsocketsDeploymentckqcOE1ebmlhFFRpE7NMKPybd4S9QPf1rsPjkB0NjI": {
       "Type": "AWS::ApiGatewayV2::Deployment",
       "DependsOn": [
         "SconnectWebsocketsRoute",
@@ -2508,12 +2427,12 @@
       },
       "DependsOn": "HttpApiIntegrationPythonHello39"
     },
-    "JavascriptHello12DashxLambdaPermissionHttpApi": {
+    "JavascriptHello14DashxLambdaPermissionHttpApi": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "FunctionName": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2545,7 +2464,7 @@
         }
       }
     },
-    "HttpApiIntegrationJavascriptHello12Dashx": {
+    "HttpApiIntegrationJavascriptHello14Dashx": {
       "Type": "AWS::ApiGatewayV2::Integration",
       "Properties": {
         "ApiId": {
@@ -2554,7 +2473,7 @@
         "IntegrationType": "AWS_PROXY",
         "IntegrationUri": {
           "Fn::GetAtt": [
-            "JavascriptHello12DashxLambdaFunction",
+            "JavascriptHello14DashxLambdaFunction",
             "Arn"
           ]
         },
@@ -2575,13 +2494,13 @@
             [
               "integrations",
               {
-                "Ref": "HttpApiIntegrationJavascriptHello12Dashx"
+                "Ref": "HttpApiIntegrationJavascriptHello14Dashx"
               }
             ]
           ]
         }
       },
-      "DependsOn": "HttpApiIntegrationJavascriptHello12Dashx"
+      "DependsOn": "HttpApiIntegrationJavascriptHello14Dashx"
     },
     "ApiGatewayLogGroupSubscription": {
       "Type": "AWS::Logs::SubscriptionFilter",
@@ -2650,15 +2569,6 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-PythonHello39LambdaFunctionQualifiedArn"
-      }
-    },
-    "JavascriptHello12DashxLambdaFunctionQualifiedArn": {
-      "Description": "Current Lambda function version",
-      "Value": {
-        "Ref": "JavascriptHello12DashxLambdaVersionXXXX"
-      },
-      "Export": {
-        "Name": "sls-dd-sls-plugin-integration-test-dev-JavascriptHello12DashxLambdaFunctionQualifiedArn"
       }
     },
     "JavascriptHello14DashxLambdaFunctionQualifiedArn": {

--- a/integration_tests/serverless-extension-apigateway.yml
+++ b/integration_tests/serverless-extension-apigateway.yml
@@ -40,9 +40,9 @@ functions:
           path: /users/update
           method: put
       - websocket: $connect
-  JavascriptHello12-x:
+  JavascriptHello14-x:
     handler: js_handler.hello
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     events:
       - http:
           path: users/create
@@ -51,9 +51,6 @@ functions:
           path: /users/remove
           method: delete
       - websocket: $connect
-  JavascriptHello14-x:
-    handler: js_handler.hello
-    runtime: nodejs14.x
   JavascriptHello16-x:
     handler: js_handler.hello
     runtime: nodejs16.x

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -30,14 +30,11 @@ functions:
   PythonHello39:
     handler: py_handler.hello
     runtime: python3.9
-  JavascriptHello12-x:
-    handler: js_handler.hello
-    runtime: nodejs12.x
-    layers:
-      - { Ref: FunctionLevelLayerLambdaLayer }
   JavascriptHello14-x:
     handler: js_handler.hello
     runtime: nodejs14.x
+    layers:
+      - { Ref: FunctionLevelLayerLambdaLayer }
   JavascriptHello16-x:
     handler: js_handler.hello
     runtime: nodejs16.x
@@ -81,7 +78,7 @@ layers:
     name: ${self:service}-${sls:stage}-ProviderLevelLayer # optional, Deployed Lambda layer name
     description: It's a text file # optional, Description to publish to AWS
     compatibleRuntimes: # optional, a list of runtimes this layer is compatible with
-      - nodejs12.x
+      - nodejs14.x
   FunctionLevelLayer:
     path: FunctionLevelLayer
     name: ${self:service}-${sls:stage}-FunctionLevelLayer # optional, Deployed Lambda layer name

--- a/integration_tests/serverless-forwarder.yml
+++ b/integration_tests/serverless-forwarder.yml
@@ -46,9 +46,9 @@ functions:
           path: /users/update
           method: put
       - websocket: $connect
-  JavascriptHello12-x:
+  JavascriptHello14-x:
     handler: js_handler.hello
-    runtime: nodejs12.x
+    runtime: nodejs14.x
     events:
       - http:
           path: users/create
@@ -57,9 +57,6 @@ functions:
           path: /users/remove
           method: delete
       - websocket: $connect
-  JavascriptHello14-x:
-    handler: js_handler.hello
-    runtime: nodejs14.x
   JavascriptHello16-x:
     handler: js_handler.hello
     runtime: nodejs16.x

--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node12-x" "Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Ruby2-7" "Datadog-Ruby2-7-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs12.x" "nodejs14.x" "nodejs16.x" "nodejs18.x" "nodejs20.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "ruby2.7" "ruby2.7-arm" "ruby3.2" "ruby3.2-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
+LAYER_NAMES=("Datadog-Node14-x" "Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Ruby2-7" "Datadog-Ruby2-7-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
+JSON_LAYER_NAMES=("nodejs14.x" "nodejs16.x" "nodejs18.x" "nodejs20.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "ruby2.7" "ruby2.7-arm" "ruby3.2" "ruby3.2-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 
 FILE_NAME="src/layers.json"

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -990,7 +990,7 @@ describe("setEnvConfiguration", () => {
         handler: {
           environment: {},
           events: [],
-          runtime: "nodejs12.x",
+          runtime: "nodejs20.x",
         },
         name: "function",
         type: RuntimeType.NODE,

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -42,7 +42,6 @@ describe("findHandlers", () => {
   it("finds all runtimes with matching layers", () => {
     const mockService = createMockService("us-east-1", {
       "go-function": { handler: "myfile.handler", runtime: "go1.10" },
-      "node12-function": { handler: "myfile.handler", runtime: "nodejs12.x" },
       "node14-function": { handler: "myfile.handler", runtime: "nodejs14.x" },
       "node16-function": { handler: "myfile.handler", runtime: "nodejs16.x" },
       "node18-function": { handler: "myfile.handler", runtime: "nodejs18.x" },
@@ -72,12 +71,6 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "go1.10" },
         type: RuntimeType.UNSUPPORTED,
         runtime: "go1.10",
-      },
-      {
-        name: "node12-function",
-        handler: { handler: "myfile.handler", runtime: "nodejs12.x" },
-        type: RuntimeType.NODE,
-        runtime: "nodejs12.x",
       },
       {
         name: "node14-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -52,7 +52,6 @@ export interface LayerJSON {
 }
 
 export const runtimeLookup: { [key: string]: RuntimeType } = {
-  "nodejs12.x": RuntimeType.NODE,
   "nodejs14.x": RuntimeType.NODE,
   "nodejs16.x": RuntimeType.NODE,
   "nodejs18.x": RuntimeType.NODE,
@@ -89,7 +88,6 @@ export const ARM_RUNTIME_KEYS: { [key: string]: string } = {
   extension: "extension-arm",
   dotnet: "dotnet-arm",
   // The same Node layers work for both x86 and ARM
-  "nodejs12.x": "nodejs12.x",
   "nodejs14.x": "nodejs14.x",
   "nodejs16.x": "nodejs16.x",
   "nodejs18.x": "nodejs18.x",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Deprecates Node.js 12.x instrumentation.

### Motivation

Node.js 12.x went in deprecation phase 2 as per [AWS Lambda Runtime Deprecation Policy](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

### Testing Guidelines

n/a

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
