### PR TITLE
feat: support `dotnet8` runtime

### DIFF
--- a/integration_tests/correct_extension_apigateway_snapshot.json
+++ b/integration_tests/correct_extension_apigateway_snapshot.json
@@ -113,6 +113,12 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello6"
       }
     },
+    "DotnetHello8LogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello8"
+      }
+    },
     "JavaHello8LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -576,6 +582,56 @@
         "DotnetHello6LogGroup"
       ]
     },
+    "DotnetHello8LambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "Handler": "dotnet_handler.hello",
+        "Runtime": "dotnet8",
+        "FunctionName": "dd-sls-plugin-integration-test-dev-DotnetHello8",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Tags": [
+          {
+            "Key": "dd_sls_plugin",
+            "Value": "vX.XX.X"
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "DD_API_KEY": 1234,
+            "DD_SITE": "datadoghq.com",
+            "DD_LOG_LEVEL": "info",
+            "DD_TRACE_ENABLED": true,
+            "DD_MERGE_XRAY_TRACES": false,
+            "DD_LOGS_INJECTION": false,
+            "DD_SERVERLESS_LOGS_ENABLED": true,
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        },
+        "Layers": [
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+        ]
+      },
+      "DependsOn": [
+        "DotnetHello8LogGroup"
+      ]
+    },
     "JavaHello8LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -839,6 +895,16 @@
       "Properties": {
         "FunctionName": {
           "Ref": "DotnetHello6LambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
+    },
+    "DotnetHello8LambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "DotnetHello8LambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -1685,6 +1751,15 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello6LambdaFunctionQualifiedArn"
+      }
+    },
+    "DotnetHello8LambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "DotnetHello8LambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello8LambdaFunctionQualifiedArn"
       }
     },
     "JavaHello8LambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_extension_snapshot.json
+++ b/integration_tests/correct_extension_snapshot.json
@@ -125,6 +125,18 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetArmHello6"
       }
     },
+    "DotnetHello8LogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello8"
+      }
+    },
+    "DotnetArmHello8LogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetArmHello8"
+      }
+    },
     "JavaHello8LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -708,6 +720,113 @@
         "DotnetArmHello6LogGroup"
       ]
     },
+    "DotnetHello8LambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "Handler": "dotnet_handler.hello",
+        "Runtime": "dotnet8",
+        "FunctionName": "dd-sls-plugin-integration-test-dev-DotnetHello8",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Tags": [
+          {
+            "Key": "dd_sls_plugin",
+            "Value": "vX.XX.X"
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "DD_API_KEY": 1234,
+            "DD_SITE": "datadoghq.com",
+            "DD_TRACE_ENABLED": true,
+            "DD_MERGE_XRAY_TRACES": false,
+            "DD_LOGS_INJECTION": false,
+            "DD_SERVERLESS_LOGS_ENABLED": true,
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        },
+        "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+        ]
+      },
+      "DependsOn": [
+        "DotnetHello8LogGroup"
+      ]
+    },
+    "DotnetArmHello8LambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "Handler": "dotnet_handler.hello",
+        "Runtime": "dotnet8",
+        "FunctionName": "dd-sls-plugin-integration-test-dev-DotnetArmHello8",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Architectures": [
+          "arm64"
+        ],
+        "Tags": [
+          {
+            "Key": "dd_sls_plugin",
+            "Value": "vX.XX.X"
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "DD_API_KEY": 1234,
+            "DD_SITE": "datadoghq.com",
+            "DD_TRACE_ENABLED": true,
+            "DD_MERGE_XRAY_TRACES": false,
+            "DD_LOGS_INJECTION": false,
+            "DD_SERVERLESS_LOGS_ENABLED": true,
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
+            "DD_SERVICE": "dd-sls-plugin-integration-test",
+            "DD_ENV": "dev"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        },
+        "Layers": [
+          {
+            "Ref": "ProviderLevelLayerLambdaLayer"
+          },
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:XXX",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+        ]
+      },
+      "DependsOn": [
+        "DotnetArmHello8LogGroup"
+      ]
+    },
     "JavaHello8LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -993,6 +1112,26 @@
         "CodeSha256": "XXXX"
       }
     },
+    "DotnetHello8LambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "DotnetHello8LambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
+    },
+    "DotnetArmHello8LambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "DotnetArmHello8LambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
+    },
     "JavaHello8LambdaVersionXXXX": {
       "Type": "AWS::Lambda::Version",
       "DeletionPolicy": "Retain",
@@ -1169,6 +1308,24 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetArmHello6LambdaFunctionQualifiedArn"
+      }
+    },
+    "DotnetHello8LambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "DotnetHello8LambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello8LambdaFunctionQualifiedArn"
+      }
+    },
+    "DotnetArmHello8LambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "DotnetArmHello8LambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetArmHello8LambdaFunctionQualifiedArn"
       }
     },
     "JavaHello8LambdaFunctionQualifiedArn": {

--- a/integration_tests/correct_forwarder_snapshot.json
+++ b/integration_tests/correct_forwarder_snapshot.json
@@ -125,6 +125,12 @@
         "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello6"
       }
     },
+    "DotnetHello8LogGroup": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": "/aws/lambda/dd-sls-plugin-integration-test-dev-DotnetHello8"
+      }
+    },
     "JavaHello8LogGroup": {
       "Type": "AWS::Logs::LogGroup",
       "Properties": {
@@ -305,6 +311,16 @@
         "FilterPattern": "",
         "LogGroupName": {
           "Ref": "DotnetHello6LogGroup"
+        }
+      }
+    },
+    "DotnetHello8LogGroupSubscription": {
+      "Type": "AWS::Logs::SubscriptionFilter",
+      "Properties": {
+        "DestinationArn": "arn:aws:lambda:us-east-1:000000000000:function:datadog-forwarder",
+        "FilterPattern": "",
+        "LogGroupName": {
+          "Ref": "DotnetHello8LogGroup"
         }
       }
     },
@@ -884,6 +900,58 @@
         "DotnetHello6LogGroup"
       ]
     },
+    "DotnetHello8LambdaFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "ServerlessDeploymentBucket"
+          },
+          "S3Key": "serverless/dd-sls-plugin-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-sls-plugin-integration-test.zip"
+        },
+        "Handler": "dotnet_handler.hello",
+        "Runtime": "dotnet8",
+        "FunctionName": "dd-sls-plugin-integration-test-dev-DotnetHello8",
+        "MemorySize": 1024,
+        "Timeout": 6,
+        "Tags": [
+          {
+            "Key": "dd_sls_plugin",
+            "Value": "vX.XX.X"
+          },
+          {
+            "Key": "service",
+            "Value": "dd-sls-plugin-integration-test"
+          },
+          {
+            "Key": "env",
+            "Value": "dev"
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "DD_SITE": "datadoghq.com",
+            "DD_LOG_LEVEL": "info",
+            "DD_FLUSH_TO_LOG": true,
+            "DD_TRACE_ENABLED": true,
+            "DD_MERGE_XRAY_TRACES": false,
+            "DD_LOGS_INJECTION": true,
+            "DD_SERVERLESS_LOGS_ENABLED": true,
+            "DD_CAPTURE_LAMBDA_PAYLOAD": false,
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper"
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "IamRoleLambdaExecution",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "DotnetHello8LogGroup"
+      ]
+    },
     "JavaHello8LambdaFunction": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
@@ -1179,6 +1247,16 @@
       "Properties": {
         "FunctionName": {
           "Ref": "DotnetHello6LambdaFunction"
+        },
+        "CodeSha256": "XXXX"
+      }
+    },
+    "DotnetHello8LambdaVersionXXXX": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "DotnetHello8LambdaFunction"
         },
         "CodeSha256": "XXXX"
       }
@@ -2384,6 +2462,15 @@
       },
       "Export": {
         "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello6LambdaFunctionQualifiedArn"
+      }
+    },
+    "DotnetHello8LambdaFunctionQualifiedArn": {
+      "Description": "Current Lambda function version",
+      "Value": {
+        "Ref": "DotnetHello8LambdaVersionXXXX"
+      },
+      "Export": {
+        "Name": "sls-dd-sls-plugin-integration-test-dev-DotnetHello8LambdaFunctionQualifiedArn"
       }
     },
     "JavaHello8LambdaFunctionQualifiedArn": {

--- a/integration_tests/serverless-extension-apigateway.yml
+++ b/integration_tests/serverless-extension-apigateway.yml
@@ -60,6 +60,9 @@ functions:
   DotnetHello6:
     handler: dotnet_handler.hello
     runtime: dotnet6
+  DotnetHello8:
+    handler: dotnet_handler.hello
+    runtime: dotnet8
   JavaHello8:
     handler: java_handler.hello
     runtime: java8

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -51,6 +51,13 @@ functions:
     handler: dotnet_handler.hello
     runtime: dotnet6
     architecture: arm64
+  DotnetHello8:
+    handler: dotnet_handler.hello
+    runtime: dotnet8
+  DotnetArmHello8:
+    handler: dotnet_handler.hello
+    runtime: dotnet8
+    architecture: arm64
   JavaHello8:
     handler: java_handler.hello
     runtime: java8

--- a/integration_tests/serverless-forwarder.yml
+++ b/integration_tests/serverless-forwarder.yml
@@ -72,6 +72,9 @@ functions:
   DotnetHello6:
     handler: dotnet_handler.hello
     runtime: dotnet6
+  DotnetHello8:
+    handler: dotnet_handler.hello
+    runtime: dotnet8
   JavaHello8:
     handler: java_handler.hello
     runtime: java8

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -362,7 +362,7 @@ describe("ServerlessPlugin", () => {
           region: "us-east-1",
         },
         functions: {
-          node1: {
+          dotnet6: {
             handler: "my-func.ev",
             layers: [],
             runtime: "dotnet6",
@@ -381,7 +381,7 @@ describe("ServerlessPlugin", () => {
     expect(serverless).toMatchObject({
       service: {
         functions: {
-          node1: {
+          dotnet6: {
             handler: "my-func.ev",
             layers: [
               expect.stringMatching(/arn\:aws\:lambda\:us\-east\-1\:.*\:layer\:dd-trace-dotnet\:.*/),

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -58,6 +58,7 @@ describe("findHandlers", () => {
       "java17-function": { handler: "myfile.handler", runtime: "java17" },
       "java21-function": { handler: "myfile.handler", runtime: "java21" },
       "dotnet6-function": { handler: "myfile.handler", runtime: "dotnet6" },
+      "dotnet8-function": { handler: "myfile.handler", runtime: "dotnet8" },
       "provided-function": { handler: "myfile.handler", runtime: "provided" },
       "provided.al2023-function": { handler: "myfile.handler", runtime: "provided.al2023" },
     });
@@ -165,6 +166,12 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "dotnet6" },
         type: RuntimeType.DOTNET,
         runtime: "dotnet6",
+      },
+      {
+        name: "dotnet8-function",
+        handler: { handler: "myfile.handler", runtime: "dotnet8" },
+        type: RuntimeType.DOTNET,
+        runtime: "dotnet8",
       },
       {
         name: "provided-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -62,6 +62,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.11": RuntimeType.PYTHON,
   "python3.12": RuntimeType.PYTHON,
   dotnet6: RuntimeType.DOTNET,
+  dotnet8: RuntimeType.DOTNET,
   java11: RuntimeType.JAVA,
   java17: RuntimeType.JAVA,
   java21: RuntimeType.JAVA,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for .NET 8 runtime.

### Motivation

It's widely available as per AWS.

### Testing Guidelines

- unit tests
- integration tests

### Additional Notes

n/a

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
