### PR TITLE
fix: Modify ASM logic to honor addExtension as well as enableASM config

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -1523,6 +1523,12 @@ describe("setEnvConfiguration", () => {
       );
     });
 
+    it("fails when `addExtension` is false", () => {
+      expect(() => setEnvConfiguration({ ...config, addExtension: false }, handlers)).toThrow(
+        "`enableASM` requires the extension to be present, and `enableDDTracing` to be enabled",
+      );
+    });
+
     it("defines `DD_SERVERLESS_APPSEC_ENABLED` and `AWS_LAMBDA_EXEC_WRAPPER`", () => {
       setEnvConfiguration(config, handlers);
       expect(handlers).toEqual([
@@ -1546,5 +1552,33 @@ describe("setEnvConfiguration", () => {
         },
       ]);
     });
+
+    it("does not define `DD_SERVERLESS_APPSEC_ENABLED` and `AWS_LAMBDA_EXEC_WRAPPER` when disabled", () => {
+      const offConfig: Configuration = {
+        ...defaultConfiguration,
+        apiKey: "1234",
+        enableASM: false
+      }
+      setEnvConfiguration(offConfig, handlers);
+      expect(handlers).toEqual([
+        {
+          handler: {
+            environment: {
+              DD_API_KEY: "1234",
+              DD_CAPTURE_LAMBDA_PAYLOAD: false,
+              DD_LOGS_INJECTION: false,
+              DD_MERGE_XRAY_TRACES: false,
+              DD_SERVERLESS_LOGS_ENABLED: true,
+              DD_SITE: "datadoghq.com",
+              DD_TRACE_ENABLED: true,
+            },
+            events: [],
+          },
+          name: "function",
+          type: RuntimeType.NODE,
+        },
+      ]);
+    });
+
   });
 });

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -1557,8 +1557,8 @@ describe("setEnvConfiguration", () => {
       const offConfig: Configuration = {
         ...defaultConfiguration,
         apiKey: "1234",
-        enableASM: false
-      }
+        enableASM: false,
+      };
       setEnvConfiguration(offConfig, handlers);
       expect(handlers).toEqual([
         {
@@ -1579,6 +1579,5 @@ describe("setEnvConfiguration", () => {
         },
       ]);
     });
-
   });
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -221,8 +221,8 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
     if (config.enableDDTracing !== undefined && environment[ddTracingEnabledEnvVar] === undefined) {
       environment[ddTracingEnabledEnvVar] = config.enableDDTracing;
     }
-    if (config.enableASM !== undefined) {
-      if (config.enableASM && !config.enableDDTracing) {
+    if (config.enableASM !== undefined && config.enableASM) {
+      if (config.enableASM && !config.enableDDTracing || config.enableASM && !config.addExtension) {
         throw new Error("`enableASM` requires the extension to be present, and `enableDDTracing` to be enabled");
       }
       environment[AWS_LAMBDA_EXEC_WRAPPER_VAR] ??= AWS_LAMBDA_EXEC_WRAPPER;

--- a/src/env.ts
+++ b/src/env.ts
@@ -222,7 +222,7 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
       environment[ddTracingEnabledEnvVar] = config.enableDDTracing;
     }
     if (config.enableASM !== undefined && config.enableASM) {
-      if (config.enableASM && !config.enableDDTracing || config.enableASM && !config.addExtension) {
+      if ((config.enableASM && !config.enableDDTracing) || (config.enableASM && !config.addExtension)) {
         throw new Error("`enableASM` requires the extension to be present, and `enableDDTracing` to be enabled");
       }
       environment[AWS_LAMBDA_EXEC_WRAPPER_VAR] ??= AWS_LAMBDA_EXEC_WRAPPER;


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
The `enableASM` functionality had two faulty logic components:
1. It never checked the value of `enableASM`, only the presence. So `enableASM: false` would still attempt to enable ASM.
2. It never checked the presence of the Datadog Extension. The Extension provides the binary used by `AWS_LAMBDA_WRAPPER` and without it, the function crashes.

### Motivation
Fixes #480

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
