### PR TITLE
Pass Step Function Context to downstream Step Function invocation

### DIFF
--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -199,6 +199,7 @@ describe("getConfig", () => {
       failOnError: false,
       skipCloudformationOutputs: false,
       mergeStepFunctionAndLambdaTraces: false,
+      propagateTraceContext: false,
       enableStepFunctionsTracing: false,
       redirectHandlers: true,
     });
@@ -239,6 +240,7 @@ describe("getConfig", () => {
       failOnError: false,
       skipCloudformationOutputs: false,
       mergeStepFunctionAndLambdaTraces: false,
+      propagateTraceContext: false,
       enableStepFunctionsTracing: false,
       redirectHandlers: true,
     });
@@ -280,6 +282,7 @@ describe("getConfig", () => {
       failOnError: false,
       skipCloudformationOutputs: false,
       mergeStepFunctionAndLambdaTraces: false,
+      propagateTraceContext: false,
       enableStepFunctionsTracing: false,
       redirectHandlers: true,
     });
@@ -321,6 +324,7 @@ it("disable source code integration", () => {
     failOnError: false,
     skipCloudformationOutputs: false,
     mergeStepFunctionAndLambdaTraces: false,
+    propagateTraceContext: false,
     enableStepFunctionsTracing: false,
     redirectHandlers: true,
   });
@@ -361,6 +365,7 @@ it("disable git metadata upload", () => {
     failOnError: false,
     skipCloudformationOutputs: false,
     mergeStepFunctionAndLambdaTraces: false,
+    propagateTraceContext: false,
     enableStepFunctionsTracing: false,
     redirectHandlers: true,
   });

--- a/src/env.ts
+++ b/src/env.ts
@@ -178,6 +178,7 @@ export const defaultConfiguration: Configuration = {
   failOnError: false,
   skipCloudformationOutputs: false,
   mergeStepFunctionAndLambdaTraces: false,
+  propagateTraceContext: false,
   enableStepFunctionsTracing: false,
   redirectHandlers: true,
 };

--- a/src/env.ts
+++ b/src/env.ts
@@ -115,6 +115,7 @@ export interface Configuration {
   // Step Functions Tracing
   enableStepFunctionsTracing?: boolean;
   mergeStepFunctionAndLambdaTraces?: boolean;
+  propagateTraceContext?: boolean;
 
   // Disables handler redirection
   // Used for testing or for someone exclusively forwarding logs

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,7 +247,7 @@ module.exports = class ServerlessPlugin {
 
         if (config.mergeStepFunctionAndLambdaTraces || config.propagateTraceContext) {
           this.serverless.cli.log(
-            `mergeStepFunctionAndLambdaTraces is true, trying to modify Step Functions' definitions to merge traces.`,
+            `mergeStepFunctionAndLambdaTraces or propagateTraceContext is true, trying to modify Step Functions' definitions to add trace context.`,
           );
           mergeStepFunctionAndLambdaTraces(resources, this.serverless);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,7 @@ module.exports = class ServerlessPlugin {
           }
         }
 
-        if (config.mergeStepFunctionAndLambdaTraces) {
+        if (config.mergeStepFunctionAndLambdaTraces || config.propagateTraceContext) {
           this.serverless.cli.log(
             `mergeStepFunctionAndLambdaTraces is true, trying to modify Step Functions' definitions to merge traces.`,
           );

--- a/src/span-link.spec.ts
+++ b/src/span-link.spec.ts
@@ -66,6 +66,25 @@ describe("mergeStepFunctionAndLambdaTraces option related tests", () => {
       expect(stepFunctionsHelper.updateDefinitionString).toBeCalledTimes(1);
     });
 
+    it("can handle a steate machine with a string DefinitionString", async () => {
+      const resources = {
+        "unit-test-state-machine": {
+          Type: "AWS::StepFunctions::StateMachine",
+          Properties: {
+            DefinitionString:
+              '{"Comment":"Some comment","StartAt":"agocsTest1","States":{"agocsTest1":{"Type":"Task","Resource":"arn:aws:states:::states:startExecution.sync:2","Parameters":{"StateMachineArn":"arn:aws:states:::states:startExecution.sync:2","Input":{"foo":"bar"}},"End":true}}}',
+          },
+        },
+        "another-resource": {
+          Type: "AWS::Lambda::Function",
+        },
+      };
+      const service = serviceWithResources();
+      const serverless: Serverless = service.serverless;
+      mergeStepFunctionAndLambdaTraces(resources, serverless);
+      expect(stepFunctionsHelper.updateDefinitionString).toBeCalledTimes(1);
+    });
+
     it("have two state machine in the resources", async () => {
       const resources = {
         "unit-test-state-machine": {

--- a/src/span-link.ts
+++ b/src/span-link.ts
@@ -11,7 +11,7 @@ export function mergeStepFunctionAndLambdaTraces(
       if (resourceObj.Type === "AWS::StepFunctions::StateMachine") {
         if (resourceObj.Properties) {
           const definitionString = resourceObj.Properties?.DefinitionString!;
-          var newDefString = updateDefinitionString(definitionString, serverless, resourceName);
+          const newDefString = updateDefinitionString(definitionString, serverless, resourceName);
           resourceObj.Properties.DefinitionString = newDefString;
         }
       }

--- a/src/span-link.ts
+++ b/src/span-link.ts
@@ -9,8 +9,11 @@ export function mergeStepFunctionAndLambdaTraces(
     if (resources.hasOwnProperty(resourceName)) {
       const resourceObj: GeneralResource = resources[resourceName];
       if (resourceObj.Type === "AWS::StepFunctions::StateMachine") {
-        const definitionString = resourceObj.Properties?.DefinitionString!;
-        updateDefinitionString(definitionString, serverless, resourceName);
+        if (resourceObj.Properties){
+          const definitionString = resourceObj.Properties?.DefinitionString!;
+          var newDefString = updateDefinitionString(definitionString, serverless, resourceName);
+          resourceObj.Properties.DefinitionString = newDefString;
+        }
       }
     }
   }

--- a/src/span-link.ts
+++ b/src/span-link.ts
@@ -9,7 +9,7 @@ export function mergeStepFunctionAndLambdaTraces(
     if (resources.hasOwnProperty(resourceName)) {
       const resourceObj: GeneralResource = resources[resourceName];
       if (resourceObj.Type === "AWS::StepFunctions::StateMachine") {
-        if (resourceObj.Properties){
+        if (resourceObj.Properties) {
           const definitionString = resourceObj.Properties?.DefinitionString!;
           var newDefString = updateDefinitionString(definitionString, serverless, resourceName);
           resourceObj.Properties.DefinitionString = newDefString;

--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -1,6 +1,6 @@
 import {
   isDefaultLambdaApiStep,
-  isSafeToModifyStepFunctionsDefinition,
+  isSafeToModifyStepFunctionLambdaInvocation,
   StateMachineDefinition,
   updateDefinitionString,
 } from "./step-functions-helper";
@@ -183,22 +183,22 @@ describe("test updateDefinitionString", () => {
 describe("test isSafeToModifyStepFunctionsDefinition", () => {
   it("Payload field not set in parameters", async () => {
     const parameters = { FunctionName: "bla" };
-    expect(isSafeToModifyStepFunctionsDefinition(parameters)).toBeTruthy();
+    expect(isSafeToModifyStepFunctionLambdaInvocation(parameters)).toBeTruthy();
   });
 
   it("Payload field empty", async () => {
     const parameters = { FunctionName: "bla", "Payload.$": {} };
-    expect(isSafeToModifyStepFunctionsDefinition(parameters)).toBeFalsy();
+    expect(isSafeToModifyStepFunctionLambdaInvocation(parameters)).toBeFalsy();
   });
 
   it("Payload field default to $", async () => {
     const parameters = { FunctionName: "bla", "Payload.$": "$" };
-    expect(isSafeToModifyStepFunctionsDefinition(parameters)).toBeTruthy();
+    expect(isSafeToModifyStepFunctionLambdaInvocation(parameters)).toBeTruthy();
   });
 
   it("Payload field default to $", async () => {
     const parameters = { FunctionName: "bla", "Payload.$": "something customer has already set and not empty" };
-    expect(isSafeToModifyStepFunctionsDefinition(parameters)).toBeFalsy();
+    expect(isSafeToModifyStepFunctionLambdaInvocation(parameters)).toBeFalsy();
   });
 });
 

--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -179,6 +179,22 @@ describe("test updateDefinitionString", () => {
       "States.JsonMerge($$, $, false)",
     );
   });
+
+  it("test step function invocation with pre-exisitng context object", async () => {
+    const definitionString = {
+      "Fn::Sub": [
+        '{"Comment": "A description of my state machine", "StartAt": "Step Functions StartExecution", "States": {"Step Functions StartExecution": {"Type": "Task", "Resource": "arn:aws:states:::states:startExecution", "Parameters": {"StateMachineArn": "arn:aws:states:us-east-1:425362996713:stateMachine:agocs-test-noop-state-machine-2", "Input": {"StatePayload": "Hello from Step Functions!", "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id", "CONTEXT.$": "something else"}}, "End": true }}}',
+        {},
+      ],
+    };
+    const stateMachineName = "fake-state-machine-name";
+    updateDefinitionString(definitionString, serverless, stateMachineName);
+
+    const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
+    expect(definitionAfterUpdate.States["Step Functions StartExecution"]?.Parameters?.Input?.["CONTEXT.$"]).toBe(
+      "something else",
+    );
+  });
 });
 
 describe("test isSafeToModifyStepFunctionLambdaInvocation", () => {

--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -163,21 +163,21 @@ describe("test updateDefinitionString", () => {
     );
   });
 
-  // it("test step function invocation without payload", async () => {
-  //   const definitionString = {
-  //     "Fn::Sub": [
-  //       '{"Comment": "A description of my state machine", "StartAt": "Step Functions StartExecution", "States": {"Step Functions StartExecution": {"Type": "Task", "Resource": "arn:aws:states:::states:startExecution", "Parameters": {"StateMachineArn": "arn:aws:states:us-east-1:425362996713:stateMachine:agocs-test-noop-state-machine-2", "Input": {"StatePayload": "Hello from Step Functions!", "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id" }}, "End": true }}}',
-  //       {},
-  //     ],
-  //   };
-  //   const stateMachineName = "fake-state-machine-name";
-  //   updateDefinitionString(definitionString, serverless, stateMachineName);
+  it("test step function invocation without input", async () => {
+    const definitionString = {
+      "Fn::Sub": [
+        '{"Comment": "A description of my state machine", "StartAt": "Step Functions StartExecution", "States": {"Step Functions StartExecution": {"Type": "Task", "Resource": "arn:aws:states:::states:startExecution", "Parameters": {"StateMachineArn": "arn:aws:states:us-east-1:425362996713:stateMachine:agocs-test-noop-state-machine-2"}, "End": true }}}',
+        {},
+      ],
+    };
+    const stateMachineName = "fake-state-machine-name";
+    updateDefinitionString(definitionString, serverless, stateMachineName);
 
-  //   const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
-  //   expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters?.["Payload.$"]).toBe(
-  //     "States.JsonMerge($$, $, false)",
-  //   );
-  // });
+    const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
+    expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters?.Input?.["CONTEXT.$"]).toBe(
+      "States.JsonMerge($$, $, false)",
+    );
+  });
 });
 
 describe("test isSafeToModifyStepFunctionsDefinition", () => {

--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -164,21 +164,21 @@ describe("test updateDefinitionString", () => {
     );
   });
 
-  // it("test step function invocation without input", async () => {
-  //   const definitionString = {
-  //     "Fn::Sub": [
-  //       '{"Comment": "A description of my state machine", "StartAt": "Step Functions StartExecution", "States": {"Step Functions StartExecution": {"Type": "Task", "Resource": "arn:aws:states:::states:startExecution", "Parameters": {"StateMachineArn": "arn:aws:states:us-east-1:425362996713:stateMachine:agocs-test-noop-state-machine-2"}, "End": true }}}',
-  //       {},
-  //     ],
-  //   };
-  //   const stateMachineName = "fake-state-machine-name";
-  //   updateDefinitionString(definitionString, serverless, stateMachineName);
+  it("test step function invocation without input", async () => {
+    const definitionString = {
+      "Fn::Sub": [
+        '{"Comment": "A description of my state machine", "StartAt": "Step Functions StartExecution", "States": {"Step Functions StartExecution": {"Type": "Task", "Resource": "arn:aws:states:::states:startExecution", "Parameters": {"StateMachineArn": "arn:aws:states:us-east-1:425362996713:stateMachine:agocs-test-noop-state-machine-2"}, "End": true }}}',
+        {},
+      ],
+    };
+    const stateMachineName = "fake-state-machine-name";
+    updateDefinitionString(definitionString, serverless, stateMachineName);
 
-  //   const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
-  //   expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters?.Input?.["CONTEXT.$"]).toBe(
-  //     "States.JsonMerge($$, $, false)",
-  //   );
-  // });
+    const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
+    expect(definitionAfterUpdate.States["Step Functions StartExecution"]?.Parameters?.Input?.["CONTEXT.$"]).toBe(
+      "States.JsonMerge($$, $, false)",
+    );
+  });
 });
 
 describe("test isSafeToModifyStepFunctionLambdaInvocation", () => {

--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -53,6 +53,16 @@ describe("test updateDefinitionString", () => {
     );
   });
 
+  it("updates the definitionstring of a StepFunction with a string definitionString", async () => {
+    const definitionString =
+      '{"Comment":"Some comment","StartAt":"agocsTest1","States":{"agocsTest1":{"Type":"Task","Resource":"arn:aws:states:::states:startExecution.sync:2","Parameters":{"StateMachineArn":"arn:aws:states:::states:startExecution.sync:2","Input":{"foo":"bar"}},"End":true}}}';
+    const stateMachineName = "fake-state-machine-name";
+    const newDefString = updateDefinitionString(definitionString, serverless, stateMachineName);
+
+    expect(typeof newDefString === "string").toBeTruthy();
+    expect(newDefString).toContain("CONTEXT");
+  });
+
   it("test lambda step without Payload", async () => {
     const definitionString = {
       "Fn::Sub": [

--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -211,7 +211,7 @@ describe("test isSafeToModifyStepFunctionInvoctation", () => {
 
   it("Input field empty", async () => {
     const parameters = { FunctionName: "bla", Input: {} };
-    expect(isSafeToModifyStepFunctionInvoctation(parameters)).toBeFalsy();
+    expect(isSafeToModifyStepFunctionInvoctation(parameters)).toBeTruthy();
   });
 
   it("Input field is not an object", async () => {
@@ -220,12 +220,12 @@ describe("test isSafeToModifyStepFunctionInvoctation", () => {
   });
 
   it("Input field has stuff in it", async () => {
-    const parameters = { FunctionName: "bla", Input: {"foo": "bar"} };
+    const parameters = { FunctionName: "bla", Input: { foo: "bar" } };
     expect(isSafeToModifyStepFunctionInvoctation(parameters)).toBeTruthy();
   });
 
   it("Input field has CONTEXT.$ already", async () => {
-    const parameters = { FunctionName: "bla", Input: {"CONTEXT.$": "something else"} };
+    const parameters = { FunctionName: "bla", Input: { "CONTEXT.$": "something else" } };
     expect(isSafeToModifyStepFunctionInvoctation(parameters)).toBeFalsy();
   });
 });

--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -146,6 +146,38 @@ describe("test updateDefinitionString", () => {
 
     expect(definitionString["Fn::Sub"].length).toBe(0);
   });
+
+  it("test step function invocation", async () => {
+    const definitionString = {
+      "Fn::Sub": [
+        '{"Comment": "A description of my state machine", "StartAt": "Step Functions StartExecution", "States": {"Step Functions StartExecution": {"Type": "Task", "Resource": "arn:aws:states:::states:startExecution", "Parameters": {"StateMachineArn": "arn:aws:states:us-east-1:425362996713:stateMachine:agocs-test-noop-state-machine-2", "Input": {"StatePayload": "Hello from Step Functions!", "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id" }}, "End": true }}}',
+        {},
+      ],
+    };
+    const stateMachineName = "fake-state-machine-name";
+    updateDefinitionString(definitionString, serverless, stateMachineName);
+
+    const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
+    expect(definitionAfterUpdate.States["Step Functions StartExecution"]?.Parameters?.Input?.["CONTEXT.$"]).toBe(
+      "States.JsonMerge($$, $, false)",
+    );
+  });
+
+  // it("test step function invocation without payload", async () => {
+  //   const definitionString = {
+  //     "Fn::Sub": [
+  //       '{"Comment": "A description of my state machine", "StartAt": "Step Functions StartExecution", "States": {"Step Functions StartExecution": {"Type": "Task", "Resource": "arn:aws:states:::states:startExecution", "Parameters": {"StateMachineArn": "arn:aws:states:us-east-1:425362996713:stateMachine:agocs-test-noop-state-machine-2", "Input": {"StatePayload": "Hello from Step Functions!", "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id" }}, "End": true }}}',
+  //       {},
+  //     ],
+  //   };
+  //   const stateMachineName = "fake-state-machine-name";
+  //   updateDefinitionString(definitionString, serverless, stateMachineName);
+
+  //   const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
+  //   expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters?.["Payload.$"]).toBe(
+  //     "States.JsonMerge($$, $, false)",
+  //   );
+  // });
 });
 
 describe("test isSafeToModifyStepFunctionsDefinition", () => {

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -16,6 +16,14 @@ export function isSafeToModifyStepFunctionLambdaInvocation(parameters: any): boo
   return false;
 }
 
+// Truth table
+// Input                    | Expected
+// -------------------------|---------
+// Empty object             | true
+// undefined                | true
+// not object               | false
+// object without CONTEXT.$ | true
+// object with CONTEXT.$    | false
 export function isSafeToModifyStepFunctionInvoctation(parameters: any): boolean {
   if (typeof parameters !== "object") {
     return false;

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -114,7 +114,7 @@ export function updateDefinitionString(
   serverless: Serverless,
   stateMachineName: string,
 ): string | { "Fn::Sub": (string | object)[] } {
-  var definitionObj: StateMachineDefinition;
+  let definitionObj: StateMachineDefinition;
 
   if (typeof definitionString !== "string") {
     // definitionString is a {"Fn::Sub": (string | object)[]}

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -87,10 +87,7 @@ export function isStepFunctionInvocation(resource: string | undefined): boolean 
   if (resource === undefined) {
     return false;
   }
-  if (resource.startsWith("arn:aws:states:::states:startExecution")) {
-    return true;
-  }
-  return false;
+  return resource.startsWith("arn:aws:states:::states:startExecution");
 }
 
 function parseDefinitionObject(definitionString: { "Fn::Sub": (string | object)[] }): StateMachineDefinition {
@@ -133,7 +130,7 @@ export function updateDefinitionString(
     if (states.hasOwnProperty(stepName)) {
       const step: StateMachineStep = states[stepName];
       if (!isDefaultLambdaApiStep(step?.Resource) && !isStepFunctionInvocation(step?.Resource)) {
-        // inject context into default Lambda API steps and Step Function invocation steps
+        // only inject context into default Lambda API steps and Step Function invocation steps
         continue;
       }
       if (isDefaultLambdaApiStep(step?.Resource)) {

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -36,7 +36,7 @@ export interface StateMachineStep {
     "Payload.$"?: string;
     Input?: {
       "CONTEXT.$": string;
-    }
+    };
   };
   Next?: string;
   End?: boolean;
@@ -62,7 +62,6 @@ export function isStepFunctionInvocation(resource: string | undefined): boolean 
     return true;
   }
   return false;
-
 }
 
 export function updateDefinitionString(
@@ -85,7 +84,7 @@ export function updateDefinitionString(
   for (const stepName in states) {
     if (states.hasOwnProperty(stepName)) {
       const step: StateMachineStep = states[stepName];
-      if (!isDefaultLambdaApiStep(step?.Resource) && (!isStepFunctionInvocation(step?.Resource))) {
+      if (!isDefaultLambdaApiStep(step?.Resource) && !isStepFunctionInvocation(step?.Resource)) {
         // inject context into default Lambda API steps and Step Function invocation steps
         continue;
       }

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -24,6 +24,11 @@ export function isSafeToModifyStepFunctionInvoctation(parameters: any): boolean 
   if (!parameters.hasOwnProperty("Input")) {
     return true;
   }
+
+  if (typeof parameters.Input !== "object") {
+    return false;
+  }
+
   if (!parameters.Input.hasOwnProperty("CONTEXT.$")) {
     return true;
   }
@@ -49,7 +54,7 @@ export interface StateMachineStep {
     FunctionName?: string;
     "Payload.$"?: string;
     Input?: {
-      "CONTEXT.$": string;
+      "CONTEXT.$"?: string;
     };
   };
   Next?: string;
@@ -117,6 +122,9 @@ export function updateDefinitionString(
         }
       } else if (isStepFunctionInvocation(step?.Resource)) {
         if (isSafeToModifyStepFunctionInvoctation(step?.Parameters)) {
+          if (step.Parameters && !step.Parameters.Input) {
+            step.Parameters.Input = {};
+          }
           step.Parameters!.Input!["CONTEXT.$"] = "States.JsonMerge($$, $, false)";
           serverless.cli.log(
             `JsonMerge StartExecution context object with Input in step: ${stepName} of state machine: ${stateMachineName}.`,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This updates the Serverless Plugin so Step Function context will be passed to downstream Step Function invocations when a Step Function invokes another Step Function

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
