### PR TITLE
Fix unresolved template variables in recommended monitor titles

### DIFF
--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -46,6 +46,33 @@ const invalidMonitorParams: MonitorParams = {
   name: "High Error Rate on {{functionname.name}} in {{region.name}} for {{aws_account.name}}",
 };
 
+const templateVariables = [
+  {
+    defaults: ["{{functionname.name}}"],
+    prefix: "",
+    name: "functionName",
+    available_values: [],
+  },
+  {
+    defaults: ["{{region.name}}"],
+    prefix: "",
+    name: "regionName",
+    available_values: [],
+  },
+  {
+    defaults: ["{{aws_account.name}}"],
+    prefix: "",
+    name: "awsAccount",
+    available_values: [],
+  },
+  {
+    defaults: ["*"],
+    prefix: "",
+    name: "scope",
+    available_values: [],
+  },
+];
+
 describe("createMonitor", () => {
   const validRequestBody = {
     body: '{"tags":["serverless_monitor_type:single_function","serverless_monitor_id:high_error_rate","aws_cloudformation_stack-id:cloudformation_stack_id","created_by:dd_sls_plugin","env:dev","service:plugin-demo-ts"],"options":{},"type":"metric alert","query":"avg(last_15m):sum:aws.lambda.errors{aws_cloudformation_stack-id:cloudformation_stack_id} by {functionname,region,aws_account}.as_count() / sum:aws.lambda.invocations{aws_cloudformation_stack-id:cloudformation_stack_id} by {functionname,region,aws_account}.as_count() >= 0.1","message":"More than 10% of the function’s invocations were errors in the selected time range. {{#is_alert}} Resolution: Examine the function’s logs, check for recent code or configuration changes with [Deployment Tracking](https://docs.datadoghq.com/serverless/deployment_tracking), or look for failures across microservices with [distributed tracing](https://docs.datadoghq.com/serverless/distributed_tracing).{{/is_alert}}","name":"High Error Rate on {{functionname.name}} in {{region.name}} for {{aws_account.name}}"}',
@@ -431,32 +458,7 @@ describe("getRecommendedMonitors", () => {
               },
               integration_title: "Serverless",
               integration_id: "serverless",
-              template_variables: [
-                {
-                  defaults: ["{{functionname.name}}"],
-                  prefix: "",
-                  name: "functionName",
-                  available_values: [],
-                },
-                {
-                  defaults: ["{{region.name}}"],
-                  prefix: "",
-                  name: "regionName",
-                  available_values: [],
-                },
-                {
-                  defaults: ["{{aws_account.name}}"],
-                  prefix: "",
-                  name: "awsAccount",
-                  available_values: [],
-                },
-                {
-                  defaults: ["*"],
-                  prefix: "",
-                  name: "scope",
-                  available_values: [],
-                },
-              ],
+              template_variables: templateVariables,
               tags: ["serverless_id:high_cold_start_rate", "created_by:dd_sls_app"],
               integration: "serverless",
               last_updated_at: 1696896000000,
@@ -674,6 +676,7 @@ describe("getRecommendedMonitors", () => {
           query: (cloudFormationStackId: string, criticalThreshold: number) => {
             return `sum(last_15m):sum:aws.lambda.enh anced.invocations{cold_start:true,${cloudFormationStackId}} by {aws_account,functionname,region}.as_count() / sum:aws.lambda.enhanced.invocations{${cloudFormationStackId}} by {aws_account,functionname,region}.as_count() >= ${criticalThreshold}`;
           },
+          templateVariables: templateVariables,
         },
         high_error_rate: {
           name: "High Error Rate on $functionName in $regionName for $awsAccount",
@@ -684,6 +687,7 @@ describe("getRecommendedMonitors", () => {
           query: (cloudFormationStackId: string, criticalThreshold: number) => {
             return `avg(last_15m):sum:aws.lambda.errors{${cloudFormationStackId}} by {functionname,region,aws_account}.as_count() / sum:aws.lambda.invocations${cloudFormationStackId}} by {functionname,region,aws_account}.as_count() >= ${criticalThreshold}`;
           },
+          templateVariables: templateVariables,
         },
         high_iterator_age: {
           name: "High Iterator Age on $functionName in $regionName for $awsAccount",
@@ -694,6 +698,7 @@ describe("getRecommendedMonitors", () => {
           query: (cloudFormationStackId: string, criticalThreshold: number) => {
             return `avg(last_15m):min:aws.lambda.iterator_age.maximum${cloudFormationStackId}} by {aws_account,region,functionname} >= ${criticalThreshold}`;
           },
+          templateVariables: templateVariables,
         },
         high_throttles: {
           name: "High Throttles on $functionName in $regionName for $awsAccount",
@@ -704,6 +709,7 @@ describe("getRecommendedMonitors", () => {
           query: (cloudFormationStackId: string, criticalThreshold: number) => {
             return `sum(last_15m):sum:aws.lambda.throttles {${cloudFormationStackId}} by {aws_account,region,functionname}.as_count() / ( sum:aws.lambda.throttles {$scope} by {aws_account,region,functionname}.as_count() + sum:aws.lambda.invocations{aws_cloudformation_stack-id:${cloudFormationStackId}} by {aws_account,region,functionname}.as_count()) >= ${criticalThreshold}`;
           },
+          templateVariables: templateVariables,
         },
       }),
     );

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -17,6 +17,11 @@ interface QueriedMonitor {
   tags: string[];
 }
 
+export interface TemplateVariable {
+  name: string;
+  defaults: string[];
+}
+
 interface RecommendedMonitorParams {
   id: string;
   attributes: {
@@ -28,6 +33,7 @@ interface RecommendedMonitorParams {
       thresholds: { [key: string]: any };
     };
     name: string;
+    template_variables: TemplateVariable[];
   };
 }
 
@@ -184,6 +190,7 @@ export async function getRecommendedMonitors(site: string, monitorsApiKey: strin
         }
         return query;
       },
+      templateVariables: recommendedMonitorParam.attributes.template_variables,
     };
 
     // recommended monitor params have an id that includes a serverless_ prefix that we have to remove to match the monitor ids we use in the plugin


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

<!--- What inspired you to submit this pull request? --->
To fix a bug that emails triggered by Serverless recommended variables contain unresolved template variables in the title, e.g. 
```
Triggered: High Error Rate on $functionName in $regionName for $awsAccount on aws_account:425362996713,functionname:yiming-serverless-demo-dev-yiming_hello,region:sa-east-1
```

<img width="856" alt="image" src="https://github.com/user-attachments/assets/eb706924-f2c3-4332-955e-79045e4acd04">

The monitor name is also incorrect on Datadog UI:

<img width="1120" alt="Screenshot 2024-07-22 at 12 48 20 PM" src="https://github.com/user-attachments/assets/934f4d84-2987-448a-868e-cfbc4adfc9c1">
where, for example, `$functionName` should be `{{functionname.name}}`.

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

replacing the dollar-formed template variables by their curly-braces-formed default values as defined in the recommended monitor JSON, e.g. replacing `$functionName` by `{{functionname.name}}`.

### Testing Guidelines

<!--- How did you test this pull request? --->

#### 1. Manual test
##### Steps
1. In the Lambda handler of a Serverless project, make the function fail:
```
def yiming_hello(event, context):
    raise Exception('Let it fail!')
```
2. Add this to `serverless.yml` of a Serverless project:
```
    monitors:
      - high_error_rate:
          tags: ["team:serverless-one", "service:yiming-serverless-demo"]
          message: "More than 10% of the function’s invocations were errors in the selected time range. Notify @yiming.luo@datadoghq.com"
```
3. Deploy the changes to Serverless sandbox AWS account, following [this internal wiki](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2722794789/Datadog+Serverless+Plugin#Local-Changes)
4. Check the monitor on Serverless UI. Check emails.

##### Results
Before: see "motivation" section.
After:
<img width="863" alt="Screenshot 2024-07-22 at 2 07 58 PM" src="https://github.com/user-attachments/assets/4720c3e9-62ff-4109-960e-7a887dcae4c1">
<img width="946" alt="Screenshot 2024-07-22 at 12 43 00 PM" src="https://github.com/user-attachments/assets/06d633cb-afaf-4ee8-b5f4-8768cb6f0680">

#### 2. Automated tests
```
npm test monitors.spec.ts
npm test monitor-api-requests.spec.ts
```

### Additional Notes

<!--- Anything else we should know when reviewing? --->

This PR assumes that every Serverless recommended monitor has template variables, at least this is true for all the 7 recommended monitors at the moment. Please let me know if this assumption is wrong.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
