### PR TITLE
Handle edge cases around template variables in recommended monitor title

### DIFF
--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -33,7 +33,7 @@ interface RecommendedMonitorParams {
       thresholds: { [key: string]: any };
     };
     name: string;
-    template_variables: TemplateVariable[];
+    template_variables?: TemplateVariable[];
   };
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation
Right now the code assumes that:
1. every recommended monitor has template variables, i.e. `template_variable` field is set in the JSON file
2. every template variable has a default value, i.e. the `default` field is an non-empty list

However,
- 1 will soon be false in that a recommended monitor with no default value is being added https://github.com/DataDog/integrations-internal-core/pull/806
- 2 is usually true, but it will be false if a monitor is misconfigured.

In either case, Serverless plugin code will throw an exception, and recommended monitors will fail to be created.

### What does this PR do?

Gracefully handle these two cases by:
1. not assuming that every recommended monitor has template variables.
2. If a template variable has no default value, then ignore it in interpolation code.

<!--- A brief description of the change being made with this pull request. --->

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

1. automated test for the new behavior:
```
npm test src/monitor-api-requests.spec.ts
npm test src/monitors.spec.ts
```
2. manual test: same as #499, to ensure that existing behavior is not broken. A recommended monitor is created successfully.

<!--- How did you test this pull request? --->

### Additional Notes

Thanks @TalUsvyatsky for guidance and @clifordshelton for pointing out these two cases.
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
