### PR TITLE
Add function return type (1/x)

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -185,7 +185,7 @@ export const defaultConfiguration: Configuration = {
   redirectHandlers: true,
 };
 
-export function setEnvConfiguration(config: Configuration, handlers: FunctionInfo[]) {
+export function setEnvConfiguration(config: Configuration, handlers: FunctionInfo[]): void {
   handlers.forEach(({ handler, type }) => {
     handler.environment ??= {};
     const environment = handler.environment as any;
@@ -290,7 +290,7 @@ export function setSourceCodeIntegrationEnvVar(
   handler: ExtendedFunctionDefinition,
   gitHash: string,
   gitRemote: string,
-) {
+): void {
   handler.environment ??= {};
   if (handler.environment[ddTagsEnvVar] !== undefined) {
     handler.environment[ddTagsEnvVar] += `,`;
@@ -300,7 +300,7 @@ export function setSourceCodeIntegrationEnvVar(
   handler.environment[ddTagsEnvVar] += `git.commit.sha:${gitHash},git.repository_url:${gitRemote}`;
 }
 
-function throwEnvVariableError(variable: string, value: string, functionName: string) {
+function throwEnvVariableError(variable: string, value: string, functionName: string): void {
   throw new Error(`Environment variable ${variable} should be set to ${value} for function ${functionName}`);
 }
 
@@ -332,7 +332,7 @@ export function getConfig(service: Service): Configuration {
   return config;
 }
 
-export function forceExcludeDepsFromWebpack(service: Service) {
+export function forceExcludeDepsFromWebpack(service: Service): void {
   const includeModules = getPropertyFromPath(service, ["custom", "webpack", "includeModules"]);
   if (includeModules === undefined) {
     return;
@@ -350,7 +350,7 @@ export function forceExcludeDepsFromWebpack(service: Service) {
   }
 }
 
-function getPropertyFromPath(obj: any, path: string[]) {
+function getPropertyFromPath(obj: any, path: string[]): any {
   for (const part of path) {
     let prop = obj[part];
     if (prop === undefined || prop === true) {
@@ -365,7 +365,7 @@ function getPropertyFromPath(obj: any, path: string[]) {
   return obj;
 }
 
-export function hasWebpackPlugin(service: Service) {
+export function hasWebpackPlugin(service: Service): boolean {
   const plugins: string[] | undefined = (service as any).plugins;
   if (plugins === undefined) {
     return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,13 +92,13 @@ module.exports = class ServerlessPlugin {
   constructor(private serverless: Serverless, private options: Serverless.Options) {}
 
   private displayedMessages: { [msg: string]: true } = {};
-  private logToCliOnce(message: string) {
+  private logToCliOnce(message: string): void {
     if (this.displayedMessages[message] === undefined) {
       this.displayedMessages[message] = true;
       this.serverless.cli.log(message);
     }
   }
-  private cliSharedInitialize() {
+  private cliSharedInitialize(): void {
     if (this.options!.function) {
       this.serverless.cli.log(
         "Warning: Using serverless deploy -f option only updates the function code and will not update CloudFormation stack (env variables included).",
@@ -106,7 +106,7 @@ module.exports = class ServerlessPlugin {
     }
   }
 
-  private async beforePackageFunction() {
+  private async beforePackageFunction(): Promise<void> {
     const config = getConfig(this.serverless.service);
     if (config.enabled === false) return;
     this.serverless.cli.log("Auto instrumenting functions with Datadog");
@@ -162,7 +162,7 @@ module.exports = class ServerlessPlugin {
     enableTracing(this.serverless.service, tracingMode, handlers);
   }
 
-  private async afterPackageCompileFunctions() {
+  private async afterPackageCompileFunctions(): Promise<void> {
     // State machines' "Properties" field will not be added until "after:package:compileFunctions"
     // hook. So we are updating Properties.Tag at this hook
 
@@ -180,7 +180,7 @@ module.exports = class ServerlessPlugin {
     }
   }
 
-  private async afterPackageFunction() {
+  private async afterPackageFunction(): Promise<void> {
     const config = getConfig(this.serverless.service);
     if (config.enabled === false) return;
 
@@ -327,7 +327,7 @@ module.exports = class ServerlessPlugin {
     }
   }
 
-  private async afterDeploy() {
+  private async afterDeploy(): Promise<void> {
     const config = getConfig(this.serverless.service);
     const custom = (this.serverless.service.custom ?? {}) as any;
     const service = custom.datadog?.service ?? this.serverless.service.getServiceName();
@@ -366,7 +366,7 @@ module.exports = class ServerlessPlugin {
     return printOutputs(this.serverless, config.site, config.subdomain, service, env);
   }
 
-  private debugLogHandlers(handlers: FunctionInfo[]) {
+  private debugLogHandlers(handlers: FunctionInfo[]): void {
     for (const handler of handlers) {
       if (handler.type === RuntimeType.UNSUPPORTED) {
         if (handler.runtime === undefined) {
@@ -384,7 +384,7 @@ module.exports = class ServerlessPlugin {
    * Check for service, env, version, and additional tags at the custom level.
    * If these don't already exsist on the function level as env vars, adds them as DD_XXX env vars
    */
-  private addDDEnvVars(handlers: FunctionInfo[]) {
+  private addDDEnvVars(handlers: FunctionInfo[]): void {
     const provider = this.serverless.service.provider as Provider;
     const service = this.serverless.service as Service;
 
@@ -425,7 +425,7 @@ module.exports = class ServerlessPlugin {
    * Check for service, env, version, and additional tags at the custom level.
    * If these tags don't already exsist on the function level, adds them as tags
    */
-  private addDDTags(handlers: FunctionInfo[]) {
+  private addDDTags(handlers: FunctionInfo[]): void {
     const service = this.serverless.service as Service;
 
     let custom = service.custom as any;
@@ -466,7 +466,7 @@ module.exports = class ServerlessPlugin {
    * as well as function level. Automatically create tags for service and env with
    * properties from deployment configurations if needed; does not override any existing values.
    */
-  private addTags(handlers: FunctionInfo[], shouldAddTags: boolean) {
+  private addTags(handlers: FunctionInfo[], shouldAddTags: boolean): void {
     const provider = this.serverless.service.provider as Provider;
     this.logToCliOnce(`Adding Plugin Version ${version} tag`);
 
@@ -491,7 +491,7 @@ module.exports = class ServerlessPlugin {
     });
   }
 
-  private extractDatadogForwarder(config: Configuration) {
+  private extractDatadogForwarder(config: Configuration): string | undefined {
     const forwarderArn: string | undefined = config.forwarderArn;
     const forwarder: string | undefined = config.forwarder;
     if (forwarderArn && forwarder) {
@@ -508,7 +508,7 @@ module.exports = class ServerlessPlugin {
   }
 };
 
-function configHasOldProperties(obj: any) {
+function configHasOldProperties(obj: any): void {
   let hasOldProperties = false;
   let message = "The following configuration options have been removed:";
 
@@ -531,7 +531,7 @@ function configHasOldProperties(obj: any) {
   }
 }
 
-function validateConfiguration(config: Configuration) {
+function validateConfiguration(config: Configuration): void {
   checkForMultipleApiKeys(config);
 
   const siteList: string[] = [
@@ -573,7 +573,7 @@ function validateConfiguration(config: Configuration) {
   }
 }
 
-function checkForMultipleApiKeys(config: Configuration) {
+function checkForMultipleApiKeys(config: Configuration): void {
   let multipleApiKeysMessage;
   if (config.apiKey !== undefined && config.apiKMSKey !== undefined && config.apiKeySecretArn !== undefined) {
     multipleApiKeysMessage = "`apiKey`, `apiKMSKey`, and `apiKeySecretArn`";


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add explicit return type for most functions in these files:
- env.ts
- forwarder.ts
- index.ts

I'm going to cover the rest of the files in future PRs, to keep each PR small and easy to review.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Most functions in the codebase don't have an explicit return type. Adding it would make code more readable, improving developer experience.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
`npm test`
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
