### PR TITLE
Remove "ok" threshold from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ custom:
             include_tags: true
             notify_audit: true
             thresholds:
-              ok: 0.025
               warning: 0.05
               critical: 0.1
 ```
@@ -198,7 +197,6 @@ custom:
             notify_audit: true
             notify_no_data: false
             thresholds:
-              ok: 1
               warning: 2
               critical: 3
 ```


### PR DESCRIPTION

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Remove "ok" threshold from README.md

<!--- A brief description of the change being made with this pull request. --->

### Motivation

There shouldn't be an "ok" threshold for recommended monitors. The examples in [Datadog monitor documentation](https://docs.datadoghq.com/api/latest/monitors) only mention `critical` and `warning` thresholds, no `ok`. (Search for `warning` on that page.)

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
