### PR TITLE
chore: Refactor and add test for sfn->Lambda context injection when P…

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -37,6 +37,20 @@ function serviceWithResources(resources?: Record<string, any>, serviceName = "my
 
 describe("test updateDefinitionString", () => {
   const serverless = serviceWithResources().serverless;
+  it("test lambda step with non-object Parameters field", async () => {
+    const definitionString = {
+      "Fn::Sub": [
+        '{"Comment":"fake comment","StartAt":"InvokeLambda","States":{"InvokeLambda":{"Type":"Task","Parameters":"Just a string!","Resource":"arn:aws:states:::lambda:invoke","End":true}}}',
+        {},
+      ],
+    };
+    const stateMachineName = "fake-state-machine-name";
+    updateDefinitionString(definitionString, serverless, stateMachineName);
+
+    const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
+    expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters).toBe("Just a string!");
+  });
+
   it("test lambda step with default payload of '$'", async () => {
     const definitionString = {
       "Fn::Sub": [

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -151,17 +151,24 @@ function updateDefinitionForDefaultLambdaApiStep(
   serverless: Serverless,
   stateMachineName: string,
 ): void {
-  if (typeof step.Parameters === "object") {
-    if (isSafeToModifyStepFunctionLambdaInvocation(step.Parameters)) {
-      step.Parameters!["Payload.$"] = "States.JsonMerge($$, $, false)";
-      serverless.cli.log(
-        `JsonMerge Step Functions context object with payload in step: ${stepName} of state machine: ${stateMachineName}.`,
-      );
-    } else {
-      serverless.cli.log(
-        `[Warn] Parameters.Payload has been set. Merging traces failed for step: ${stepName} of state machine: ${stateMachineName}`,
-      );
-    }
+  if (typeof step.Parameters !== "object") {
+    serverless.cli.log(
+      `[Warn] Parameters field is not a JSON object. Merging traces failed for step: ${stepName} of state machine: ${stateMachineName}. \
+Your Step Functions trace will not be merged with downstream Lambda traces. To manually merge these traces, check out \
+https://docs.datadoghq.com/serverless/step_functions/troubleshooting/`,
+    );
+    return;
+  }
+
+  if (isSafeToModifyStepFunctionLambdaInvocation(step.Parameters)) {
+    step.Parameters!["Payload.$"] = "States.JsonMerge($$, $, false)";
+    serverless.cli.log(
+      `JsonMerge Step Functions context object with payload in step: ${stepName} of state machine: ${stateMachineName}.`,
+    );
+  } else {
+    serverless.cli.log(
+      `[Warn] Parameters.Payload has been set. Merging traces failed for step: ${stepName} of state machine: ${stateMachineName}`,
+    );
   }
 }
 


### PR DESCRIPTION
…arameters is string

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

When the `Parameters` field of an "InvokeLambda" step is a string instead of an object, currently we skip context injection.

This PR:
1. refactors code by flipping `if` condition
2. print a warning message in this case
3. add a test case

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Pass the added test

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
