### PR TITLE
feat: Support sfn->Lambda context injection when no Payload exists (case 1)

### DIFF
--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -47,6 +47,7 @@ export interface StateMachineStep {
   Parameters?: {
     FunctionName?: string;
     "Payload.$"?: string;
+    Payload?: string;
     Input?: {
       "CONTEXT.$"?: string;
     };
@@ -144,11 +145,9 @@ https://docs.datadoghq.com/serverless/step_functions/troubleshooting/`,
     return;
   }
 
-  if (!step.Parameters.hasOwnProperty("Payload.$")) {
-    step.Parameters!["Payload.$"] = "States.JsonMerge($$, $, false)";
-    serverless.cli.log(
-      `JsonMerge Step Functions context object with payload in step: ${stepName} of state machine: ${stateMachineName}.`,
-    );
+  if (!step.Parameters.hasOwnProperty("Payload.$") && !step.Parameters.hasOwnProperty("Payload")) {
+    step.Parameters!["Payload.$"] = "$$['Execution', 'State', 'StateMachine']";
+    serverless.cli.log(`Merging traces for step: ${stepName} of state machine: ${stateMachineName}.`);
     return;
   }
 


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->
### Current behavior:
In the Lambda step definition,
- If `Payload.$` doesn't exist, then inject context using `States.JsonMerge($$, $, false)`
- We don't check if `Payload` exists. The current behavior when `Payload` exists is that we also try to inject context using `States.JsonMerge($$, $, false)`. Then there would be an error when `serverless deploy` is run, saying `Payload` and `Payload.$` can't both exist, which can be confusing to users.

### What does this PR do?
Change context injection behavior so that if `Payload.$` or `Payload` don't exist, then inject context using:
```
$$['Execution', 'State', 'StateMachine']
```

This corresponds to Case 1 in the design doc [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit#bookmark=id.pczh1xpu3h9y)

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated tests
Passed the existing and added tests

#### Manual tests
##### Steps
1. Create a State Machine with a Lambda step which has no Payload or Payload.$
```
InvokeLambdaStep:
  Type: Task
  Resource: arn:aws:states:::lambda:invoke
  Parameters:
    FunctionName:
      Fn::GetAtt: [yiming_plugin_hello, Arn]
    # Payload.$: $
  End: true
```

2. Run `serverless deploy`.
3. Check the State Machine definition in AWS UI

##### Result

Context was injected as expected:
```
    "InvokeLambdaStep": {
      "Type": "Task",
      "Resource": "arn:aws:states:::lambda:invoke",
      "Parameters": {
        "FunctionName": "arn:aws:lambda:sa-east-1:425362996713:function:yiming-serverless-demo-dev-yiming_plugin_hello",
        "Payload.$": "$$['Execution', 'State', 'StateMachine']"
      },
      "End": true
    }
```
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
