### PR TITLE
feat: Skip sfn->Lambda context injection when Payload is not object (case 3)

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -116,6 +116,19 @@ describe("test updateDefinitionString", () => {
     );
   });
 
+  it("test lambda step when Payload is not an object", async () => {
+    const definitionString = {
+      "Fn::Sub": [
+        '{"Comment":"fake comment","StartAt":"InvokeLambda","States":{"InvokeLambda":{"Type":"Task","Parameters":{"FunctionName":"fake-function-name","Payload":"Just a string!"},"Resource":"arn:aws:states:::lambda:invoke","End":true}}}',
+        {},
+      ],
+    };
+    updateDefinitionString(definitionString, serverless, stateMachineName);
+
+    const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
+    expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters?.["Payload"]).toBe("Just a string!");
+  });
+
   it("test lambda step with custom Payload", async () => {
     const definitionString = {
       "Fn::Sub": [

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -151,6 +151,18 @@ https://docs.datadoghq.com/serverless/step_functions/troubleshooting/`,
     return;
   }
 
+  if (step.Parameters.hasOwnProperty("Payload")) {
+    const payload = step.Parameters.Payload;
+    if (typeof payload !== "object") {
+      serverless.cli.log(
+        `[Warn] Payload field is not a JSON object. Merging traces failed for step: ${stepName} of state machine: ${stateMachineName}. \
+  Your Step Functions trace will not be merged with downstream Lambda traces. To manually merge these traces, check out \
+  https://docs.datadoghq.com/serverless/step_functions/troubleshooting/`,
+      );
+      return;
+    }
+  }
+
   if (step.Parameters["Payload.$"] === "$") {
     // $ % is the default original unchanged payload
     step.Parameters!["Payload.$"] = "States.JsonMerge($$, $, false)";


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
If `Payload` field of a Lambda invoke step is not a JSON object, then skip context injection.
<!--- A brief description of the change being made with this pull request. --->

This corresponds to Case 2 in the design doc [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit#bookmark=id.pczh1xpu3h9y)

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Passed the added test
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
