### PR TITLE
chore: Refactor sfn->Lambda context injection code by moving code

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -66,7 +66,7 @@ describe("test updateDefinitionString", () => {
     );
   });
 
-  it("test lambda step with empty payload", async () => {
+  it("Case 4.3: test lambda step with empty payload", async () => {
     const definitionString = {
       "Fn::Sub": [
         '{"Comment":"fake comment","StartAt":"InvokeLambda","States":{"InvokeLambda":{"Type":"Task","Parameters":{"FunctionName":"fake-function-name","Payload.$":{}},"Resource":"arn:aws:states:::lambda:invoke","End":true}}}',
@@ -79,7 +79,7 @@ describe("test updateDefinitionString", () => {
     expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters?.["Payload.$"]).toStrictEqual({});
   });
 
-  it("test lambda step with custom payload", async () => {
+  it("Case 4.3: test lambda step with custom payload", async () => {
     const definitionString = {
       "Fn::Sub": [
         '{"Comment":"fake comment","StartAt":"InvokeLambda","States":{"InvokeLambda":{"Type":"Task","Parameters":{"FunctionName":"fake-function-name","Payload.$":"$$.State"},"Resource":"arn:aws:states:::lambda:invoke","End":true}}}',
@@ -101,7 +101,7 @@ describe("test updateDefinitionString", () => {
     expect(newDefString).toContain("CONTEXT");
   });
 
-  it("test lambda step without Payload or Payload.$", async () => {
+  it("Case 1: test lambda step without Payload or Payload.$", async () => {
     const definitionString = {
       "Fn::Sub": [
         '{"Comment":"fake comment","StartAt":"InvokeLambda","States":{"InvokeLambda":{"Type":"Task","Parameters":{"FunctionName":"fake-function-name"},"Resource":"arn:aws:states:::lambda:invoke","End":true}}}',


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
1. Add comments
2. Right now the order of cases are:
```
if (!has("Payload.$") && !has("Payload")) {
  // Case 1 code
  return;
}

if (has("Payload")) {
  // Case 2 & 3 code
  return;
}

if (has("Payload.$")) {
  // Case 4 code
  return;
}
```

This PR changes it to
```
if (has("Payload")) {
  // Case 2 & 3 code
  return;
}

if (has("Payload.$")) {
  // Case 4 code
  return;
}

// Case 1 code
return;
```
to simplify the `if` conditions.

3. Change, for example:
```
if () {
  // Case 2.1 code
} else if () {
  // Case 2.2 code
} else {
  // Case 2.3 code
  return;
}
```
to 
```
if () {
  // Case 2.1 code
  return;
}

if () {
  // Case 2.2 code
  return;
}

// Case 2.3 code
}
return
```

I don't have a strong opinion on making this change. I weakly think the code is more readable this way because the code sections for handling each case are more separate.

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Documentation and for code readability
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Pass existing tests
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
