### PR TITLE
Support sfn->sfn context injection when no context field exists (case 1)

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -295,7 +295,7 @@ describe("test updateDefinitionString", () => {
 
     const definitionAfterUpdate: StateMachineDefinition = JSON.parse(definitionString["Fn::Sub"][0] as string);
     const input = definitionAfterUpdate.States["Step Functions StartExecution"]?.Parameters?.Input as StepFunctionInput;
-    expect(input["CONTEXT.$"]).toBe("States.JsonMerge($$, $, false)");
+    expect(input["CONTEXT.$"]).toBe("$$['Execution', 'State', 'StateMachine']");
   });
 
   it("test step function invocation without input", async () => {
@@ -334,7 +334,7 @@ describe("test updateDefinitionForStepFunctionInvocationStep", () => {
     expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeTruthy();
   });
 
-  it("Input field empty", async () => {
+  it("Case 1: Input field empty", async () => {
     const parameters = { FunctionName: "bla", Input: {} };
     const step = { Parameters: parameters };
     expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeTruthy();
@@ -346,7 +346,7 @@ describe("test updateDefinitionForStepFunctionInvocationStep", () => {
     expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeFalsy();
   });
 
-  it("Input field has stuff in it", async () => {
+  it('Case 1: Input field has stuff in it but no "CONTEXT" or "CONTEXT.$"', async () => {
     const parameters = { FunctionName: "bla", Input: { foo: "bar" } };
     const step = { Parameters: parameters };
     expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeTruthy();

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -26,6 +26,7 @@ export type PayloadObject = {
 
 export type StepFunctionInput = {
   "CONTEXT.$"?: string;
+  CONTEXT?: string;
   [key: string]: unknown;
 };
 
@@ -255,8 +256,9 @@ export function updateDefinitionForStepFunctionInvocationStep(step: StateMachine
     return false;
   }
 
-  if (!parameters.Input.hasOwnProperty("CONTEXT.$")) {
-    parameters.Input["CONTEXT.$"] = "States.JsonMerge($$, $, false)";
+  // Case 1: No "CONTEXT" or "CONTEXT.$"
+  if (!parameters.Input.hasOwnProperty("CONTEXT") && !parameters.Input.hasOwnProperty("CONTEXT.$")) {
+    parameters.Input["CONTEXT.$"] = "$$['Execution', 'State', 'StateMachine']";
     return true;
   }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Supports Case 1 of Step Function -> Step Function context injection: if no `CONTEXT` or `CONTEXT.$` field exists, then add:
```
"CONTEXT.$": "$$['Execution', 'State', 'StateMachine']"
```

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes
See all the cases in the design doc [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit#bookmark=id.15flqi5dkv9i)
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
