### PR TITLE
chore: Fix warning when sfn->Lambda context injection is already set up using "Payload"

### DIFF
--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -188,7 +188,7 @@ https://docs.datadoghq.com/serverless/step_functions/troubleshooting/`,
     ) {
       // Case 2.1: already injected into "Payload"
       serverless.cli.log(
-        `Context injection is already set up. Skipping merging traces for step: ${stepName} of state machine: \${stateMachineName}.\n`,
+        `Context injection is already set up. Skipping merging traces for step: ${stepName} of state machine: ${stateMachineName}.\n`,
       );
 
       return;


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Problem
If Step Function -> Lambda context injection is already set up using `serverless.yml`, like
```
              Payload:
                Execution.$: $$.Execution
                State.$: $$.State
                StateMachine.$: $$.StateMachine
                action: delete_customers
```
our plugin will print a warning:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/2e59a35d-d8d3-4db3-bd3b-bac329245bc8">
where `stateMachineName` is not resolved.

### What does this PR do?
Make `stateMachineName` resolve to the real name.
<!--- A brief description of the change being made with this pull request. --->

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Steps
Define a State Machine, which invokes a Lambda function, where context injection is already set up:
```
functions:
  yiming_plugin_hello:
    handler: handler.yiming_plugin_hello

stepFunctions:
  stateMachines:
    yimingServerlessPluginTestStateMachine:
      name: YimingServerlessPluginTestStateMachine
      definition:
        Comment: "A Hello World example of the Amazon States Language using an AWS Lambda Function."
        StartAt: InvokeLambdaStep
        States:
          InvokeLambdaStep:
            Type: Task
            Resource: arn:aws:states:::lambda:invoke
            Parameters:
              FunctionName:
                Fn::GetAtt: [yiming_plugin_hello, Arn]
              Payload:
                Execution.$: $$.Execution
                State.$: $$.State
                StateMachine.$: $$.StateMachine
                action: delete_customers
            End: true
```
and run `serverless deploy`
#### Result
<img width="759" alt="image" src="https://github.com/user-attachments/assets/11cf221b-87db-4a84-9f4a-713c05cf9404">

`stateMachineName` is resolved
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
