### PR TITLE
chore: Fix message when sfn->Lambda context injection is already set …

### DIFF
--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -236,7 +236,7 @@ merge these traces, check out https://docs.datadoghq.com/serverless/step_functio
       step.Parameters["Payload.$"] === "$$['Execution', 'State', 'StateMachine']"
     ) {
       serverless.cli.log(
-        `[Warn] Step ${stepName} of state machine ${stateMachineName}: Context injection is already set up. Skipping context injection.\n`,
+        `Step ${stepName} of state machine ${stateMachineName}: Context injection is already set up. Skipping context injection.\n`,
       );
 
       return;


### PR DESCRIPTION
…up using Payload.$

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->


### Motivation
If `serverless.yml` is already setting up sfn->Lambda context injection using the `Payload.$` field:
```
Payload.$: "States.JsonMerge($$, $, false)"
```
right now our plugin will print a message:
<img width="751" alt="image" src="https://github.com/user-attachments/assets/f4166fdc-80cb-4723-ac4d-d2f1e1c78bd0">

This shouldn't be a `[Warn]`. We usually only add `[Warn]` when context injection is not set up yet and skipped for some reason.
<!--- A brief description of the change being made with this pull request. --->

### What does this PR do?
Remove the `[Warn]`
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
<img width="757" alt="image" src="https://github.com/user-attachments/assets/cd20a7ce-f7ee-4821-986d-772a8c9d2632">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
