### PR TITLE
Skip sfn->sfn context injection when CONTEXT field exists (case 2)

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -328,34 +328,43 @@ describe("test updateDefinitionString", () => {
 });
 
 describe("test updateDefinitionForStepFunctionInvocationStep", () => {
+  const stepName = "Step Functions StartExecution";
+  const serverless = serviceWithResources().serverless;
+  const stateMachineName = "fake-state-machine-name";
   it("Input field not set in parameters", async () => {
     const parameters = { FunctionName: "bla" };
     const step = { Parameters: parameters };
-    expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeTruthy();
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeTruthy();
   });
 
   it("Case 1: Input field empty", async () => {
     const parameters = { FunctionName: "bla", Input: {} };
     const step = { Parameters: parameters };
-    expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeTruthy();
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeTruthy();
   });
 
   it("Input field is not an object", async () => {
     const parameters = { FunctionName: "bla", Input: "foo" };
     const step = { Parameters: parameters };
-    expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeFalsy();
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
   });
 
   it('Case 1: Input field has stuff in it but no "CONTEXT" or "CONTEXT.$"', async () => {
     const parameters = { FunctionName: "bla", Input: { foo: "bar" } };
     const step = { Parameters: parameters };
-    expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeTruthy();
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeTruthy();
+  });
+
+  it('Case 2: Input field has "CONTEXT" field', async () => {
+    const parameters = { FunctionName: "bla", Input: { CONTEXT: "foo" } };
+    const step = { Parameters: parameters };
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
   });
 
   it("Input field has CONTEXT.$ already", async () => {
     const parameters = { FunctionName: "bla", Input: { "CONTEXT.$": "something else" } };
     const step = { Parameters: parameters };
-    expect(updateDefinitionForStepFunctionInvocationStep(step)).toBeFalsy();
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
   });
 });
 

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -256,9 +256,14 @@ export function updateDefinitionForStepFunctionInvocationStep(step: StateMachine
     return false;
   }
 
+<<<<<<< HEAD
   // Case 1: No "CONTEXT" or "CONTEXT.$"
   if (!parameters.Input.hasOwnProperty("CONTEXT") && !parameters.Input.hasOwnProperty("CONTEXT.$")) {
     parameters.Input["CONTEXT.$"] = "$$['Execution', 'State', 'StateMachine']";
+=======
+  if (!parameters.Input.hasOwnProperty("CONTEXT.$")) {
+    parameters.Input["CONTEXT.$"] = "States.JsonMerge($$, $, false)";
+>>>>>>> 5b7d0de (chore: Refactor sfn->sfn context injection code by merging two functions)
     return true;
   }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
If the `Parameter.Input` field has custom `CONTEXT`, then skip context injection and print a warning.
This case should be rare, so we don't support this case for now. We can consider supporting it if a client actually complains.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Passed the added test
<!--- How did you test this pull request? --->

### Additional Notes
See all the cases in the design doc [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit#bookmark=id.15flqi5dkv9i)
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
