### PR TITLE
Skip sfn->sfn context injection when CONTEXT.$ field exists (case 3)

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -361,7 +361,19 @@ describe("test updateDefinitionForStepFunctionInvocationStep", () => {
     expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
   });
 
-  it("Input field has CONTEXT.$ already", async () => {
+  it("Case 3.1: Context injection already set up using States.JsonMerge($$, $, false)", async () => {
+    const parameters = { FunctionName: "bla", Input: { "CONTEXT.$": "States.JsonMerge($$, $, false)" } };
+    const step = { Parameters: parameters };
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
+  });
+
+  it("Case 3.1: Context injection already set up using $$['Execution', 'State', 'StateMachine']", async () => {
+    const parameters = { FunctionName: "bla", Input: { "CONTEXT.$": "$$['Execution', 'State', 'StateMachine']" } };
+    const step = { Parameters: parameters };
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
+  });
+
+  it("Case 3.2: Input field has a custom CONTEXT.$ field", async () => {
     const parameters = { FunctionName: "bla", Input: { "CONTEXT.$": "something else" } };
     const step = { Parameters: parameters };
     expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -278,6 +278,24 @@ merge these traces, check out https://docs.datadoghq.com/serverless/step_functio
     return false;
   }
 
+  // Case 3.1 context injection is already set up
+  if (
+    parameters.Input["CONTEXT.$"] === "States.JsonMerge($$, $, false)" ||
+    parameters.Input["CONTEXT.$"] === `$$['Execution', 'State', 'StateMachine']`
+  ) {
+    serverless.cli.log(
+      `Step ${stepName} of state machine ${stateMachineName}: Context injection is already set up. Skipping context injection.\n`,
+    );
+
+    return false;
+  }
+
+  // Case 3.2 custom CONTEXT.$ field
+  serverless.cli
+    .log(`[Warn] Step ${stepName} of state machine ${stateMachineName}: Parameters.Input field has a custom CONTEXT.$ field. Step \
+Functions Context Object injection skipped. Your Step Functions trace will not be merged with downstream Step Function traces. To \
+manually merge these traces, check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\n`);
+
   return false;
 }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Skip Step Function -> Step Function context injection when the `Parameters.Input` field has `CONTEXT.$` field:
- Case 3.1: the client already set up context injection in their serverless.yml using
    - `$$['Execution', 'State', 'StateMachine']` or 
    - `States.JsonMerge($$, $, false)` 
    - (This should be rare though. Maybe we don't need to support this case.)
- Case 3.2: There's custom `CONTEXT.$` field. Print a warning in this case.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Passed the added tests

<!--- How did you test this pull request? --->

### Additional Notes
See all the cases in the design doc [Fixing Step Function Instrumentation](https://docs.google.com/document/d/18YpNVN6reCjA-dq6U1Tfs2MyLxcVnjO_N8Uy9Gm_BGM/edit#bookmark=id.15flqi5dkv9i)
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
