### PR TITLE
Add doc for sfn->sfn context injection when Input does not exist (case 0)

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -331,7 +331,8 @@ describe("test updateDefinitionForStepFunctionInvocationStep", () => {
   const stepName = "Step Functions StartExecution";
   const serverless = serviceWithResources().serverless;
   const stateMachineName = "fake-state-machine-name";
-  it("Input field not set in parameters", async () => {
+
+  it("Case 0.2: Input field not set in parameters", async () => {
     const parameters = { FunctionName: "bla" };
     const step = { Parameters: parameters };
     expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeTruthy();
@@ -343,7 +344,7 @@ describe("test updateDefinitionForStepFunctionInvocationStep", () => {
     expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeTruthy();
   });
 
-  it("Input field is not an object", async () => {
+  it("Case 0.3: Input field is not an object", async () => {
     const parameters = { FunctionName: "bla", Input: "foo" };
     const step = { Parameters: parameters };
     expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -241,6 +241,18 @@ check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\
 // not object               | false
 // object without CONTEXT.$ | true
 // object with CONTEXT.$    | false
+
+// Truth table
+// Case | Input                                                    | Expected
+// -----|----------------------------------------------------------|---------
+//  0.1 | Parameters field is not an object                        | false
+//  0.2 | Parameters field has no Input field                      | true
+//  0.3 | Parameters.Input is not an object                        | false
+//   1  | No "CONTEXT" or "CONTEXT.$"                              | true
+//   2  | Has "CONTEXT"                                            | false
+//  3.1 | "CONTEXT.$": "States.JsonMerge($$, $, false)" or         | false
+//      | "CONTEXT.$": "$$['Execution', 'State', 'StateMachine']"  |
+//  3.2 | Custom "CONTEXT.$"                                       | false
 export function updateDefinitionForStepFunctionInvocationStep(
   stepName: string,
   step: StateMachineStep,
@@ -248,15 +260,19 @@ export function updateDefinitionForStepFunctionInvocationStep(
   stateMachineName: string,
 ): boolean {
   const parameters = step?.Parameters;
+
+  // Case 0.1: Parameters field is not an object
   if (typeof parameters !== "object") {
     return false;
   }
 
+  // Case 0.2: Parameters field has no Input field
   if (!parameters.hasOwnProperty("Input")) {
     parameters.Input = { "CONTEXT.$": "States.JsonMerge($$, $, false)" };
     return true;
   }
 
+  // Case 0.3: Parameters.Input is not an object
   if (typeof parameters.Input !== "object") {
     return false;
   }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
For Step Function -> Step Function context injection, there's some existing code handling the case when `Parameter.Input` doesn't exist. This PR tries to organize them by making them "Case 0", and add doc for it.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
N/A. Just doc updates.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
