### PR TITLE
Create GitHub action to publish npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish packages on NPM
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "18.x"
+      - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
+        env:
+          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - run: yarn
+      - run: yarn build
+      - run: yarn publish
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Send success message to Slack
+        env:
+          SLACK_CHANNEL: "#serverless-onboarding-and-enablement-ops"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        if: success()
+        run: |
+          set -x
+          OPS_MESSAGE=":gh-check-passed: serverless-plugin-datadog NPM publish succeeded!"
+          curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{
+            "channel": "'"$SLACK_CHANNEL"'",
+            "text": "'"$OPS_MESSAGE"'"
+          }'
+
+      - name: Send failure message to Slack
+        env:
+          SLACK_CHANNEL: "#serverless-onboarding-and-enablement-ops"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()
+        run: |
+          set -x
+          OPS_MESSAGE=":gh-check-passed: serverless-plugin-datadog NPM publish failed!
+          Please check GitHub Action log: https://github.com/DataDog/serverless-plugin-datadog/actions/workflows/publish.yml"
+          curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{
+            "channel": "'"$SLACK_CHANNEL"'",
+            "text": "'"$OPS_MESSAGE"'"

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -68,9 +68,6 @@ if [ "$UPDATE_LAYERS" != "false" ]; then
     fi
 fi
 
-# Verify NPM access before updating layer arns (slow)
-yarn login
-
 if [ "$UPDATE_LAYERS" != "false" ]; then
     aws-vault exec sso-govcloud-us1-fed-engineering -- aws sts get-caller-identity
     aws-vault exec sso-prod-engineering -- aws sts get-caller-identity
@@ -92,11 +89,7 @@ echo
 echo "Bumping the version number and committing the changes"
 yarn version --new-version "$VERSION"
 
-echo
-echo 'Publishing to npm'
-yarn
 yarn build
-yarn publish --new-version "$VERSION"
 
 echo
 echo 'Pushing updates to GitHub'
@@ -104,5 +97,5 @@ git push origin main
 git push origin "refs/tags/v$VERSION"
 
 echo
-echo "DONE! Please create a new release using the link below."
+echo "DONE! Please create a new release using the link below. It will trigger a GitHub action to publish to npm."
 echo "https://github.com/DataDog/serverless-plugin-datadog/releases/new?tag=v$VERSION&title=v$VERSION"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation
Right now, when someone wants to publish a release for this repo by running `publish_prod.sh`, they need to reach out to someone to request an NPM token for themselves, one token for each person. This is not scalable. As @astuyve and @yoannmoinet suggested, let's set up a GitHub action to release the npm package.

<!--- What inspired you to submit this pull request? --->

### Previous work
1. I granted @yoannmoinet admin permission of this repo
2. @yoannmoinet added an NPM token as a secret of this repo
3. I revoked admin permission from @yoannmoinet

### What does this PR do?
Set up a GitHub Action to release the npm package following this internal wiki: [Publish a package on NPM](https://datadoghq.atlassian.net/wiki/spaces/~194742439/pages/4180476110/Publish+a+package+on+NPM#)

A message will be sent to Slack channel `serverless-onboarding-and-enablement-ops` with the success/failure result.
<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
I'm not sure how to test it without actually creating a release. I'd test it in production. i.e.
1. merge this commit
2. run `publish_prod.sh`, which creates a release and will ideally trigger the GitHub Action

To test Slack messaging, I added this GitHub action, which successfully sent a message.
```
name: Yiming's Slack test
on: [push]
jobs:
  build:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout
        uses: actions/checkout@v3

  notify:
    runs-on: ubuntu-latest
    needs: build
    steps:
      - name: Send success message to Slack
        env:
          SLACK_CHANNEL: "#serverless-onboarding-and-enablement-ops"
          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
        if: success()
        run: |
          set -x
          OPS_MESSAGE=":gh-check-passed: Yiming is testing Slack bot!"
          curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{
            "channel": "'"$SLACK_CHANNEL"'",
            "text": "'"$OPS_MESSAGE"'"
          }'
```

<img width="256" alt="image" src="https://github.com/user-attachments/assets/ec5e155e-bcde-4f0c-8db2-cd9c9c2d76f6">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
