### PR TITLE
Fix recommended monitor operations

### DIFF
--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -437,7 +437,7 @@ describe("getRecommendedMonitors", () => {
         data: [
           {
             type: "recommended-monitor",
-            id: "serverless_high_cold_start_rate",
+            id: "serverless-[enhanced_metrics]_lambda_function_cold_start_rate_is_high",
             attributes: {
               classification: "metric",
               query:
@@ -473,7 +473,7 @@ describe("getRecommendedMonitors", () => {
           },
           {
             type: "recommended-monitor",
-            id: "serverless_high_error_rate",
+            id: "serverless-lambda_function_invocations_are_failing",
             attributes: {
               classification: "metric",
               query:
@@ -534,7 +534,7 @@ describe("getRecommendedMonitors", () => {
           },
           {
             type: "recommended-monitor",
-            id: "serverless_high_iterator_age",
+            id: "serverless-lambda_function's_iterator_age_is_increasing",
             attributes: {
               classification: "metric",
               query:
@@ -595,7 +595,7 @@ describe("getRecommendedMonitors", () => {
           },
           {
             type: "recommended-monitor",
-            id: "serverless_high_throttles",
+            id: "serverless-lambda_function_invocations_are_throttling",
             attributes: {
               classification: "metric",
               query:

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -37,6 +37,19 @@ interface RecommendedMonitorParams {
   };
 }
 
+/**
+ * Maps recommended monitor API IDs to IDs, where "API IDs" mean the keys in the monitor API response JSON
+ */
+const recommendedMonitorApiIdToId = {
+  "serverless-lambda_function_invocations_are_failing": "high_error_rate",
+  "serverless-lambda_function_is_timing_out": "timeout",
+  "serverless-[enhanced_metrics]_lambda_function_is_running_out_of_memory": "out_of_memory",
+  "serverless-lambda_function's_iterator_age_is_increasing": "high_iterator_age",
+  "serverless-[enhanced_metrics]_lambda_function_cold_start_rate_is_high": "high_cold_start_rate",
+  "serverless-lambda_function_invocations_are_throttling": "high_throttles",
+  "serverless-[enhanced_metrics]_lambda_function_cost_is_increasing": "increased_cost",
+};
+
 export async function createMonitor(
   site: string,
   monitorParams: MonitorParams,
@@ -210,10 +223,18 @@ export async function getRecommendedMonitors(
       templateVariables: recommendedMonitorParam.attributes.template_variables,
     };
 
-    // recommended monitor params have an id that includes a serverless_ prefix that we have to remove to match the monitor ids we use in the plugin
-    const recommendedMonitorId = recommendedMonitorParam.id.replace("serverless_", "");
-    recommendedMonitors[recommendedMonitorId] = recommendedMonitor;
+    const recommendedMonitorApiId = recommendedMonitorParam.id;
+    if (isValidRecommendedMonitorApiId(recommendedMonitorApiId)) {
+      const recommendedMonitorId = recommendedMonitorApiIdToId[recommendedMonitorApiId];
+      recommendedMonitors[recommendedMonitorId] = recommendedMonitor;
+    }
   });
 
   return recommendedMonitors;
+}
+
+function isValidRecommendedMonitorApiId(
+  recommendedMonitorApiId: string,
+): recommendedMonitorApiId is keyof typeof recommendedMonitorApiIdToId {
+  return recommendedMonitorApiId in recommendedMonitorApiIdToId;
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Problem
Due to a change in monitor API response format, Serverless Plugin fails to parse the response. The response used to be like:
```
{"high_error_rate": {...}}
```
but it's now:
```
{"serverless-lambda_function_invocations_are_failing": {...}}
```

Issue: https://github.com/DataDog/serverless-plugin-datadog/issues/545
Incident 31902.
<!--- What inspired you to submit this pull request? --->

### What does this PR do?
This is a quick and temporary fix for the issue that recommended monitors can't be created or updated.

Details:
1. Add a hard-coded map from "monitor ID" like `high_error_rate` to the "API ID" like `serverless-lambda_function_invocations_are_failing`.
2. When processing the API response for recommended monitors, change the "API ID" to "monitor ID"
<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
#### Automated Testing
Passed the modified test. The test was modified so that the mocked API response format matches the current prod format. The test can pass, which means the plugin is able to handle this format.

#### Manual Testing
##### Steps:
1. Update a stack with all the 7 recommended monitors. The stack had a `high_error_rate` monitor before the update.
```
datadog:
    ...
    monitors:
      - high_error_rate:
          tags: ["team:serverless"]
      - timeout:
          tags: ["team:serverless"]
      - out_of_memory:
          tags: ["team:serverless"]
      - high_iterator_age:
          tags: ["team:serverless"]
      - high_cold_start_rate:
          tags: ["team:serverless"]
      - high_throttles:
          tags: ["team:serverless"]
      - increased_cost:
          tags: ["team:serverless"]
```
2. Run `serverless deploy`

##### Result:

All the 7 monitors have been updated or created. They all appear in Datadog App.
<img width="758" alt="image" src="https://github.com/user-attachments/assets/78895884-5731-499a-a80d-2f27289f2952">
<img width="886" alt="image" src="https://github.com/user-attachments/assets/ce4d130a-a8d4-4171-be97-e77f8d96ee3c">

<!--- How did you test this pull request? --->

### Additional Notes

Next steps:
- Work with Monitor team to find a long term fix. We should avoid using the hard-coded map. We should be able to use some info in the response to identify the correct monitor without any map.

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
