### PR TITLE
chore: Run monitor API test at 9am every day

### DIFF
--- a/.github/workflows/monitor_api_integration_test.yml
+++ b/.github/workflows/monitor_api_integration_test.yml
@@ -1,0 +1,51 @@
+name: monitor-api-integration-test
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # 1pm UTC (9am EDT, 8am EST), every day
+    - cron: "0 13 * * *"
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Cache Node modules
+        id: cache-node-modules
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Test getting recommended monitors
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+        run: npm run test:integration
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    steps:
+      - name: Send failure message to Slack
+        env:
+          SLACK_CHANNEL: "#serverless-onboarding-and-enablement-ops"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()
+        run: |
+          set -x
+          OPS_MESSAGE=":gh-check-passed: Serverless Plugin failed to fetch recommended monitors from monitor API!
+          Please check GitHub Action log: https://github.com/DataDog/serverless-plugin-datadog/actions/workflows/monitor_api_integration_test.yml"
+          curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{
+          "channel": "'"$SLACK_CHANNEL"'",
+          "text": "'"$OPS_MESSAGE"'"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

There's a GitHub action testing if Serverless Plugin can fetch the recommended monitors properly from monitor API. Right now it runs on push and pull_request. This PR makes it also run at 9am EDT every day, and notify serverless-onboarding-and-enablement-ops channel if the test fails.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Test in prod
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
