### PR TITLE
Fix Slack message for monitor API test failure

### DIFF
--- a/.github/workflows/monitor_api_integration_test.yml
+++ b/.github/workflows/monitor_api_integration_test.yml
@@ -44,7 +44,7 @@ jobs:
         if: failure()
         run: |
           set -x
-          OPS_MESSAGE=":gh-check-passed: Serverless Plugin failed to fetch recommended monitors from monitor API!
+          OPS_MESSAGE=":gh-check-failed: Serverless Plugin failed to fetch recommended monitors from monitor API!
           Please check GitHub Action log: https://github.com/DataDog/serverless-plugin-datadog/actions/workflows/monitor_api_integration_test.yml"
           curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{
           "channel": "'"$SLACK_CHANNEL"'",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fix the icon in the Slack message for monitor API test failure.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
