### PR TITLE
Change state machine tag key from DD_XYZ to xyz

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1872,7 +1872,7 @@ describe("ServerlessPlugin", () => {
       );
     });
 
-    it("sets DD tags for the state machine", async () => {
+    it("sets tags for the state machine", async () => {
       const serverless = {
         cli: { log: () => {} },
         getProvider: (_name: string) => awsMock(),
@@ -1912,15 +1912,15 @@ describe("ServerlessPlugin", () => {
       ).toHaveProperty(
         "Tags",
         expect.arrayContaining([
-          { Key: "DD_ENV", Value: "prod" },
-          { Key: "DD_SERVICE", Value: "my-service" },
-          { Key: "DD_VERSION", Value: "1.0.0" },
+          { Key: "env", Value: "prod" },
+          { Key: "service", Value: "my-service" },
+          { Key: "version", Value: "1.0.0" },
           { Key: "dd-custom-tag", Value: "custom-tag-value" },
         ]),
       );
     });
 
-    it("does not override existing DD tags on the state machine", async () => {
+    it("does not override existing tags on the state machine", async () => {
       const serverless = {
         cli: { log: () => {} },
         getProvider: (_name: string) => awsMock(),
@@ -1934,9 +1934,9 @@ describe("ServerlessPlugin", () => {
                   Type: "AWS::StepFunctions::StateMachine",
                   Properties: {
                     Tags: [
-                      { Key: "DD_ENV", Value: "dev" },
-                      { Key: "DD_SERVICE", Value: "my-existing-service" },
-                      { Key: "DD_VERSION", Value: "0.0.9" },
+                      { Key: "env", Value: "dev" },
+                      { Key: "service", Value: "my-existing-service" },
+                      { Key: "version", Value: "0.0.9" },
                       { Key: "dd-custom-tag", Value: "existing-tag-value" },
                     ],
                   },
@@ -1967,9 +1967,9 @@ describe("ServerlessPlugin", () => {
       ).toHaveProperty(
         "Tags",
         expect.arrayContaining([
-          { Key: "DD_ENV", Value: "dev" },
-          { Key: "DD_SERVICE", Value: "my-existing-service" },
-          { Key: "DD_VERSION", Value: "0.0.9" },
+          { Key: "env", Value: "dev" },
+          { Key: "service", Value: "my-existing-service" },
+          { Key: "version", Value: "0.0.9" },
           { Key: "dd-custom-tag", Value: "existing-tag-value" },
         ]),
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ module.exports = class ServerlessPlugin {
         }
         addDdSlsPluginTag(stateMachineObj); // obj is a state machine object
         addDdTraceEnabledTag(stateMachineObj, config.enableStepFunctionsTracing);
-        this.addDDTagsForStateMachine(stateMachineObj);
+        this.addTagsForStateMachine(stateMachineObj);
       }
     }
   }
@@ -464,9 +464,9 @@ module.exports = class ServerlessPlugin {
 
   /**
    * Check for service, env, version, and additional tags at the custom level.
-   * If these don't already exsist on the state machine level, add them as DD_XXX tags.
+   * If these don't already exist on the state machine level, add them.
    */
-  private addDDTagsForStateMachine(stateMachine: any): void {
+  private addTagsForStateMachine(stateMachine: any): void {
     const service = this.serverless.service as Service;
 
     const datadog = service.custom?.datadog;
@@ -480,21 +480,21 @@ module.exports = class ServerlessPlugin {
 
     if (datadog.service && !tags.hasOwnProperty(TagKeys.Service)) {
       tags.push({
-        Key: ddServiceEnvVar,
+        Key: TagKeys.Service,
         Value: datadog.service,
       });
     }
 
     if (datadog.env && !tags.hasOwnProperty(TagKeys.Env)) {
       tags.push({
-        Key: ddEnvEnvVar,
+        Key: TagKeys.Env,
         Value: datadog.env,
       });
     }
 
     if (datadog.version && !tags.hasOwnProperty(TagKeys.Version)) {
       tags.push({
-        Key: ddVersionEnvVar,
+        Key: TagKeys.Version,
         Value: datadog.version,
       });
     }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Background
https://github.com/DataDog/serverless-plugin-datadog/pull/552 sets `DD_ENV`, `DD_SERVICE` and `DD_VERSION` tags on the state machines.

### Motivation
From [the "custom" approach of instrumenting a state machine](https://docs.datadoghq.com/serverless/step_functions/installation/?tab=custom), we should set `env`, `service` and `version`, not the `DD_XXX` ones. 
<!--- What inspired you to submit this pull request? --->

### What does this PR do?
Makes plugin set `env`, `service` and `version` tags on the state machine instead of the `DD_XXX` ones.
<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
Passed the touched tests.
<!--- How did you test this pull request? --->

### Additional Notes
Need a review from Cloud Tracing team, who, as the downstream consumer, should know what tags should be set here.
<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
