### PR TITLE
Fix Slack bot for monitor API test failure

### DIFF
--- a/.github/workflows/monitor_api_integration_test.yml
+++ b/.github/workflows/monitor_api_integration_test.yml
@@ -1,8 +1,6 @@
 name: monitor-api-integration-test
 
 on:
-  push:
-  pull_request:
   schedule:
     # 1pm UTC (9am EDT, 8am EST), every day
     - cron: "0 13 * * *"
@@ -33,10 +31,6 @@ jobs:
           DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
         run: npm run test:integration
 
-  notify:
-    runs-on: ubuntu-latest
-    needs: integration-tests
-    steps:
       - name: Send failure message to Slack
         env:
           SLACK_CHANNEL: "#serverless-onboarding-and-enablement-ops"
@@ -49,3 +43,4 @@ jobs:
           curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{
           "channel": "'"$SLACK_CHANNEL"'",
           "text": "'"$OPS_MESSAGE"'"
+          }'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fix the Slack bot triggered by monitor API integration test failure, similar to https://github.com/DataDog/serverless-self-monitoring/pull/286

<!--- A brief description of the change being made with this pull request. --->

### Motivation
I believe the bot is not working now for the same reason as the bot in self monitoring.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Steps:
- throw an exception in `getRecommendedMonitors()`
- push

Result: Slack bot is triggered.
<img width="666" alt="image" src="https://github.com/user-attachments/assets/707cf203-eb08-4cdc-929b-9bbaf8418011">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
