### PR TITLE
chore: Fix npm publish GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "18.x"
-      - run: yarn config set npmAuthToken $NPM_PUBLISH_TOKEN
-        env:
-          NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          registry-url: "https://registry.npmjs.org"
       - run: yarn
       - run: yarn build
       - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation
The GitHub Action added in https://github.com/DataDog/serverless-plugin-datadog/pull/540 failed to publish the npm package on release event. [GitHub Action log](https://github.com/DataDog/serverless-plugin-datadog/actions/runs/11960303068/job/33344004054) says
> error No token found and can't prompt for login when running with --non-interactive.

<!--- What inspired you to submit this pull request? --->

### What does this PR do?

Change the way to set npm publish token, following this discussion:
https://github.com/actions/setup-node/issues/81#issuecomment-623018474
<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
#### Steps
1. Add this to `publish.yml`
```diff
on:
  release:
    types: [created]
+ push:
```
2. Push the commit

#### Result
The previous error is gone, and a new error appears:
> Couldn't publish package: "https://registry.npmjs.org/serverless-plugin-datadog: You cannot publish over the previously published versions: 5.74.0."

I think we can assume it's a success.

[GitHub Action log](https://github.com/DataDog/serverless-plugin-datadog/actions/runs/11960802481/job/33345624991)
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
