### PR TITLE
Fix Slack bot for npm publish failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
-  notify:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Send success message to Slack
         env:
           SLACK_CHANNEL: "#serverless-onboarding-and-enablement-ops"
@@ -41,8 +37,9 @@ jobs:
         if: failure()
         run: |
           set -x
-          OPS_MESSAGE=":gh-check-passed: serverless-plugin-datadog NPM publish failed!
+          OPS_MESSAGE=":gh-check-failed: serverless-plugin-datadog NPM publish failed!
           Please check GitHub Action log: https://github.com/DataDog/serverless-plugin-datadog/actions/workflows/publish.yml"
           curl -H "Content-type: application/json" -X POST "$SLACK_WEBHOOK" -d '{
             "channel": "'"$SLACK_CHANNEL"'",
             "text": "'"$OPS_MESSAGE"'"
+          }'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation
NPM publish failed, but Slack bot step was skipped.
<!--- What inspired you to submit this pull request? --->

### What does this PR do?
Fix the Slack bot triggered by npm publish failure, similar to https://github.com/DataDog/serverless-self-monitoring/pull/286

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
#### Steps
1. Add this to `publish.yml`
```diff
on:
  release:
    types: [created]
+ push:
```
2. Push

#### Result
Message was sent:
<img width="842" alt="image" src="https://github.com/user-attachments/assets/43a7a419-b0ae-4820-8415-7fd0c812eecb">


<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
