### PR TITLE
Allow for legacy lambda steps for step functions

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -1,5 +1,5 @@
 import {
-  isDefaultLambdaApiStep,
+  isLambdaApiStep,
   StateMachineDefinition,
   updateDefinitionString,
   updateDefinitionForStepFunctionInvocationStep,
@@ -223,7 +223,7 @@ describe("test updateDefinitionString", () => {
     expect(definitionAfterUpdate.States?.InvokeLambda?.Parameters?.["Payload.$"]).toBe("something-customized");
   });
 
-  it("test lambda basic legacy integration do nothing", async () => {
+  it("test lambda legacy integration with undefined parameters do nothing", async () => {
     const definitionString = {
       "Fn::Sub": [
         '{"Comment":"fake comment","StartAt":"InvokeLambda","States":{"InvokeLambda":{"Type":"Task","Resource":"arn:aws:lambda:sa-east-1:601427271234:function:unit-test-function-name","End":true}}}',
@@ -254,7 +254,7 @@ describe("test updateDefinitionString", () => {
     });
   });
 
-  it("test legacy lambda api do nothing", async () => {
+  it("test legacy lambda context is injected", async () => {
     const definitionString = {
       "Fn::Sub": [
         '{"Comment":"fake comment","StartAt":"InvokeLambda","States":{"InvokeLambda":{"Type":"Task","Parameters":{"FunctionName":"fake-function-name","Payload.$":"$"},"Resource":"arn:aws:lambda:sa-east-1:601427271234:function:unit-test-function-name","End":true}}}',
@@ -268,7 +268,7 @@ describe("test updateDefinitionString", () => {
       End: true,
       Parameters: {
         FunctionName: "fake-function-name",
-        "Payload.$": "$",
+        "Payload.$": "States.JsonMerge($$, $, false)",
       },
       Resource: "arn:aws:lambda:sa-east-1:601427271234:function:unit-test-function-name",
       Type: "Task",
@@ -381,29 +381,29 @@ describe("test updateDefinitionForStepFunctionInvocationStep", () => {
   });
 });
 
-describe("test isDefaultLambdaApiStep", () => {
+describe("test isLambdaApiStep", () => {
   it("resource is default lambda", async () => {
     const resource = "arn:aws:states:::lambda:invoke";
-    expect(isDefaultLambdaApiStep(resource)).toBeTruthy();
+    expect(isLambdaApiStep(resource)).toBeTruthy();
   });
 
   it("resource is lambda arn for legacy lambda api", async () => {
     const resource = "arn:aws:lambda:sa-east-1:601427271234:function:hello-function";
-    expect(isDefaultLambdaApiStep(resource)).toBeFalsy();
+    expect(isLambdaApiStep(resource)).toBeTruthy();
   });
 
   it("resource of dynamodb", async () => {
     const resource = "arn:aws:states:::dynamodb:updateItem";
-    expect(isDefaultLambdaApiStep(resource)).toBeFalsy();
+    expect(isLambdaApiStep(resource)).toBeFalsy();
   });
 
   it("resource of empty string", async () => {
     const resource = "";
-    expect(isDefaultLambdaApiStep(resource)).toBeFalsy();
+    expect(isLambdaApiStep(resource)).toBeFalsy();
   });
 
   it("resource of undefined", async () => {
     const resource = undefined;
-    expect(isDefaultLambdaApiStep(resource)).toBeFalsy();
+    expect(isLambdaApiStep(resource)).toBeFalsy();
   });
 });


### PR DESCRIPTION
### What does this PR do?

This PR allows for a step function with a lambda step defined in the "legacy" way to have context injection done and allow for traces to be combined.  From the [JIRA](https://datadoghq.atlassian.net/browse/SVLS-5638)

> A Step Function State Machine can invoke a Lambda function or a nested State Machine. The outer state machine, inner state machine and the Lambda function can all have their own traces.
>
> To merge their traces (so that, for example, [their flame graph can be combined](https://private-user-images.githubusercontent.com/10097700/387345806-202ed91a-f034-42e9-83c8-12e82fa101e2.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzMxNzM5NTksIm5iZiI6MTczMzE3MzY1OSwicGF0aCI6Ii8xMDA5NzcwMC8zODczNDU4MDYtMjAyZWQ5MWEtZjAzNC00MmU5LTgzYzgtMTJlODJmYTEwMWUyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEyMDIlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMjAyVDIxMDczOVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTliNDU1Y2MwNGEyNTk5ZWQ5ZGIxZDc0NGE4NTE0ZDE0MGYxYzI3M2IyZDA2ZjBhZjQ5NmJlYmU2MzFkMDU5MGUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.1FWfi9JYhk5jiuXa_mKpfuxIuvmpFsg52EwZ-jHLcJo)), we need to alter the Payload field of the Lambda Invoke state and the Input field of the Step Function Execution state, so the necessary fields can be passed from the outer state machine into the inner state machine and the Lambda function. We sometimes call this “context injection”.


### Motivation

Lambdas defined using the legacy way in step function steps are supported, so customers should be allowed to merge traces using them.

### Testing Guidelines



I created a test serverless application with the following definition:

```
service: alex-angelillo-test-serverless

frameworkVersion: '3'

provider:
  name: aws
  runtime: python3.9
  region: sa-east-1
  iam:
    role:
      statements:
        # Allow functions to list all buckets
        - Effect: Allow
          Action: 's3:ListBucket'
          Resource: '*'
        # Allow functions to read/write objects in a bucket
        - Effect: Allow
          Action:
            - 'secretsmanager:GetSecretValue'
          Resource:
            - 'arn:aws:secretsmanager:sa-east-1:425362996713:secret:DdApiKeySecret-z0ThpAcdYRuN-lLEvzk'

stepFunctions:
  stateMachines:
    hellostepfunc1:
      name: Alex-Angelillo-test-state-machine
      definition:
        Comment: "A Hello World example of the Amazon States Language using an AWS Lambda Function"
        StartAt: HelloWorld1
        States:
          HelloWorld1:
            Type: Task
            Resource: arn:aws:lambda:sa-east-1:425362996713:function:alex-angelillo-test-serverless-dev-hello
            Parameters: {}
            End: true

functions:
  hello:
    handler: handler.hello

plugins:
  - serverless-plugin-datadog
  - serverless-step-functions
custom:
  datadog:
    site: datad0g.com
    apiKeySecretArn: arn:aws:secretsmanager:sa-east-1:425362996713:secret:DdApiKeySecret-z0ThpAcdYRuN-lLEvzk
    testingMode: true
    DD_TRACE_OTEL_ENABLED: false
    DD_PROFILING_ENABLED: false
    DD_SERVERLESS_APPSEC_ENABLED: false
    enableDDLogs: true
    forwarderArn: arn:aws:lambda:sa-east-1:425362996713:function:datadog-forwarder-alex-angelillo-Forwarder-I5Qg0CoOKvBl
    enableStepFunctionsTracing: true
    propagateUpstreamTrace: true
    mergeStepFunctionAndLambdaTraces: true
```

The lambda in question does an sts call to get its own identity, handler code

```
import json
import boto3


def hello(event, context):
    client = boto3.client('sts')
    res = client.get_caller_identity()
    print(res)
    body = {
        "message": "Go Serverless v3.0! Your function executed successfully!",
        "input": event,
    }

    return {"statusCode": 200, "body": json.dumps(body)}

```

I made the changes in this PR to the serverless plugin and linked that to the test application.  Once it was deployed the step function was instrumented and combined the lambda and stepfunction traces, as seen in [this trace](https://dd.datad0g.com/apm/trace/4796969035395040527?graphType=flamegraph&shouldShowLegend=true&sort=time&spanID=5083889400429149931&timeHint=1734461428113.9998)

![image](https://github.com/user-attachments/assets/280b3cfe-2d5b-4685-a007-15a168a03cad)

Additionally, unit tests.

### Additional Notes

N/A

### Commit
Allow context injection for legacy step function steps using lambda.

JIRA: https://datadoghq.atlassian.net/browse/SVLS-5638

### Types of changes

- [ ] Bug fix
- [x] New feature - ish, this is expanding support for an existing feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
