### PR TITLE
[SVLS-3973] Add/modify API key log messages

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -8,7 +8,7 @@
 
 import Service from "serverless/classes/Service";
 import { ExtendedFunctionDefinition, FunctionInfo, runtimeLookup, RuntimeType } from "./layer";
-import { logMessage } from "output";
+import { logMessage } from "./output";
 
 export interface Configuration {
   // Whether Datadog is enabled. Defaults to true.

--- a/src/env.ts
+++ b/src/env.ts
@@ -203,7 +203,7 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
       config.apiKeySecretArn === undefined
     ) {
       environment[apiKeyEnvVar] = process.env.DATADOG_API_KEY;
-      logMessage("Using DATADOG_API_KEY env var for authentication");
+      logMessage("Using DATADOG_API_KEY environment variable for authentication");
     }
     if (config.apiKey !== undefined && environment[apiKeyEnvVar] === undefined) {
       environment[apiKeyEnvVar] = config.apiKey;

--- a/src/env.ts
+++ b/src/env.ts
@@ -202,6 +202,7 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
       config.apiKeySecretArn === undefined
     ) {
       environment[apiKeyEnvVar] = process.env.DATADOG_API_KEY;
+      console.log("Using DATADOG_API_KEY env var for authentication");
     }
     if (config.apiKey !== undefined && environment[apiKeyEnvVar] === undefined) {
       environment[apiKeyEnvVar] = config.apiKey;

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,6 +8,7 @@
 
 import Service from "serverless/classes/Service";
 import { ExtendedFunctionDefinition, FunctionInfo, runtimeLookup, RuntimeType } from "./layer";
+import { logMessage } from "output";
 
 export interface Configuration {
   // Whether Datadog is enabled. Defaults to true.
@@ -202,7 +203,7 @@ export function setEnvConfiguration(config: Configuration, handlers: FunctionInf
       config.apiKeySecretArn === undefined
     ) {
       environment[apiKeyEnvVar] = process.env.DATADOG_API_KEY;
-      console.log("Using DATADOG_API_KEY env var for authentication");
+      logMessage("Using DATADOG_API_KEY env var for authentication");
     }
     if (config.apiKey !== undefined && environment[apiKeyEnvVar] === undefined) {
       environment[apiKeyEnvVar] = config.apiKey;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -842,7 +842,7 @@ describe("ServerlessPlugin", () => {
   it("allows use of DATADOG_API_KEY and DATADOG_APP_KEY to create monitors", async () => {
     process.env.DATADOG_API_KEY = "1234";
     process.env.DATADOG_APP_KEY = "5678";
-    
+
     const serverless = {
       cli: {
         log: () => {},

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -834,7 +834,7 @@ describe("ServerlessPlugin", () => {
       }
       expect(threwError).toBe(true);
       expect(thrownErrorMessage).toEqual(
-        "When `addExtension` is true, the environment variable `DATADOG_API_KEY` or configuration variable `apiKMSKey` or `apiKeySecretArn` must be set.",
+        "The environment variable `DATADOG_API_KEY` or configuration variable `apiKMSKey` or `apiKeySecretArn` must be set because `addExtension` is set to true as default.",
       );
     });
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -842,7 +842,7 @@ describe("ServerlessPlugin", () => {
   it("allows use of DATADOG_API_KEY and DATADOG_APP_KEY to create monitors", async () => {
     process.env.DATADOG_API_KEY = "1234";
     process.env.DATADOG_APP_KEY = "5678";
-    mock({});
+    
     const serverless = {
       cli: {
         log: () => {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -607,7 +607,7 @@ function validateConfiguration(config: Configuration): void {
       config.apiKeySecretArn === undefined
     ) {
       throw new Error(
-        "`The environment variable `DATADOG_API_KEY` or configuration variable `apiKMSKey` or `apiKeySecretArn` must be set because `addExtension` is set to true as default.",
+        "The environment variable `DATADOG_API_KEY` or configuration variable `apiKMSKey` or `apiKeySecretArn` must be set because `addExtension` is set to true as default.",
       );
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -607,7 +607,7 @@ function validateConfiguration(config: Configuration): void {
       config.apiKeySecretArn === undefined
     ) {
       throw new Error(
-        "When `addExtension` is true, the environment variable `DATADOG_API_KEY` or configuration variable `apiKMSKey` or `apiKeySecretArn` must be set.",
+        "`The environment variable `DATADOG_API_KEY` or configuration variable `apiKMSKey` or `apiKeySecretArn` must be set because `addExtension` is set to true as default.",
       );
     }
   }

--- a/src/output.ts
+++ b/src/output.ts
@@ -76,6 +76,6 @@ function logHeader(message: string, underline = false): void {
   console.log(`${startFont}${message}${endFont}`);
 }
 
-function logMessage(message: string): void {
+export function logMessage(message: string): void {
   console.log(`  ${message}`);
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

* adds new log message to indicate that the plugin is using the `DD_API_KEY` env var for authentication if it is set
* update the missing API key error message to reflect that addExtension: true is the default now

### Motivation

<!--- What inspired you to submit this pull request? --->

See [ticket](https://datadoghq.atlassian.net/browse/SVLS-3973?atlOrigin=eyJpIjoiOTYwNGUxNTJlNGMwNDliNDg1OTNmYzcyNzc4ODc4MmQiLCJwIjoiaiJ9)

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
