### PR TITLE
chore: Change Slack channel for npm publish success notification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Send success message to Slack
         env:
-          SLACK_CHANNEL: "#serverless-onboarding-and-enablement-ops"
+          SLACK_CHANNEL: "#serverless-releases"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         if: success()
         run: |


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

<img width="415" alt="image" src="https://github.com/user-attachments/assets/89783393-4e61-46ad-9dfc-6d3d165295c8" />

npm publish success events notify `serverless-onboarding-and-enablement-ops` Slack channel a lot, which is noisy. I think it's better to move it to a lower-signal channel: `serverless-releases`. Failure events will still notify the high-signal channel `serverless-onboarding-and-enablement-ops` for further actions.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
