### PR TITLE
feat: Support Ruby 3.3

### DIFF
--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Node22-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Python313" "Datadog-Python313-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs16.x" "nodejs18.x" "nodejs20.x" "nodejs22.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "python3.13" "python3.13-arm" "ruby3.2" "ruby3.2-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
+LAYER_NAMES=("Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Node22-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Python313" "Datadog-Python313-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Ruby3-3" "Datadog-Ruby3-3-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
+JSON_LAYER_NAMES=("nodejs16.x" "nodejs18.x" "nodejs20.x" "nodejs22.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "python3.13" "python3.13-arm" "ruby3.2" "ruby3.2-arm" "ruby3.3" "ruby3.3-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
 
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 

--- a/src/layers-gov.json
+++ b/src/layers-gov.json
@@ -20,10 +20,12 @@
       "python3.13-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-java:18"
     },
     "us-gov-east-1": {
@@ -46,10 +48,12 @@
       "python3.13-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-java:18"
     }
   }

--- a/src/layers.json
+++ b/src/layers.json
@@ -20,10 +20,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-south-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-south-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-south-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-south-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-south-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-south-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-south-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-south-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-south-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-south-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-south-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-south-2:464622532012:layer:dd-trace-java:18"
     },
     "ap-south-1": {
@@ -46,10 +48,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-south-1:464622532012:layer:dd-trace-java:18"
     },
     "eu-south-1": {
@@ -72,10 +76,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-south-1:464622532012:layer:dd-trace-java:18"
     },
     "eu-south-2": {
@@ -98,10 +104,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-south-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-south-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-south-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-south-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-south-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-south-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-south-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-south-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-south-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-south-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-south-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-south-2:464622532012:layer:dd-trace-java:18"
     },
     "me-central-1": {
@@ -124,10 +132,12 @@
       "python3.13-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:me-central-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:me-central-1:464622532012:layer:dd-trace-java:18"
     },
     "il-central-1": {
@@ -149,10 +159,12 @@
       "python3.13-arm": "arn:aws:lambda:il-central-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:il-central-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:il-central-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:il-central-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:il-central-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:il-central-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:il-central-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:il-central-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:il-central-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:il-central-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:il-central-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:il-central-1:464622532012:layer:dd-trace-java:18"
     },
     "ca-central-1": {
@@ -175,17 +187,19 @@
       "python3.13-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ca-central-1:464622532012:layer:dd-trace-java:18"
     },
     "mx-central-1": {
       "extension": "arn:aws:lambda:mx-central-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:mx-central-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:mx-central-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:mx-central-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:mx-central-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:mx-central-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:mx-central-1:464622532012:layer:dd-trace-java:18"
     },
     "eu-central-1": {
@@ -208,10 +222,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-central-1:464622532012:layer:dd-trace-java:18"
     },
     "eu-central-2": {
@@ -234,10 +250,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-central-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-central-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-central-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-central-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-central-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-central-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-central-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-central-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-central-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-central-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-central-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-central-2:464622532012:layer:dd-trace-java:18"
     },
     "us-west-1": {
@@ -260,10 +278,12 @@
       "python3.13-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:us-west-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:us-west-1:464622532012:layer:dd-trace-java:18"
     },
     "us-west-2": {
@@ -286,10 +306,12 @@
       "python3.13-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:us-west-2:464622532012:layer:dd-trace-java:18"
     },
     "af-south-1": {
@@ -312,10 +334,12 @@
       "python3.13-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:af-south-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:af-south-1:464622532012:layer:dd-trace-java:18"
     },
     "eu-north-1": {
@@ -338,10 +362,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-north-1:464622532012:layer:dd-trace-java:18"
     },
     "eu-west-3": {
@@ -364,10 +390,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-west-3:464622532012:layer:dd-trace-java:18"
     },
     "eu-west-2": {
@@ -390,10 +418,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-west-2:464622532012:layer:dd-trace-java:18"
     },
     "eu-west-1": {
@@ -416,10 +446,12 @@
       "python3.13-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:eu-west-1:464622532012:layer:dd-trace-java:18"
     },
     "ap-northeast-3": {
@@ -442,10 +474,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-northeast-3:464622532012:layer:dd-trace-java:18"
     },
     "ap-northeast-2": {
@@ -468,10 +502,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-northeast-2:464622532012:layer:dd-trace-java:18"
     },
     "me-south-1": {
@@ -494,10 +530,12 @@
       "python3.13-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:me-south-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:me-south-1:464622532012:layer:dd-trace-java:18"
     },
     "ap-northeast-1": {
@@ -520,10 +558,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-northeast-1:464622532012:layer:dd-trace-java:18"
     },
     "sa-east-1": {
@@ -546,10 +586,12 @@
       "python3.13-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:18"
     },
     "ap-east-1": {
@@ -572,10 +614,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-east-1:464622532012:layer:dd-trace-java:18"
     },
     "ca-west-1": {
@@ -597,10 +641,12 @@
       "python3.13-arm": "arn:aws:lambda:ca-west-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ca-west-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ca-west-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ca-west-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ca-west-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ca-west-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ca-west-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ca-west-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ca-west-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ca-west-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ca-west-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ca-west-1:464622532012:layer:dd-trace-java:18"
     },
     "ap-southeast-1": {
@@ -623,10 +669,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-southeast-1:464622532012:layer:dd-trace-java:18"
     },
     "ap-southeast-2": {
@@ -649,10 +697,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-southeast-2:464622532012:layer:dd-trace-java:18"
     },
     "ap-southeast-3": {
@@ -675,10 +725,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-southeast-3:464622532012:layer:dd-trace-java:18"
     },
     "ap-southeast-4": {
@@ -701,10 +753,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-southeast-4:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-southeast-4:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-southeast-4:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-southeast-4:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-southeast-4:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-southeast-4:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-southeast-4:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-southeast-4:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-southeast-4:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-southeast-4:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-southeast-4:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-southeast-4:464622532012:layer:dd-trace-java:18"
     },
     "us-east-1": {
@@ -727,10 +781,12 @@
       "python3.13-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:18"
     },
     "ap-southeast-5": {
@@ -752,10 +808,12 @@
       "python3.13-arm": "arn:aws:lambda:ap-southeast-5:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:ap-southeast-5:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:ap-southeast-5:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:ap-southeast-5:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:ap-southeast-5:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:ap-southeast-5:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-southeast-5:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-southeast-5:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-southeast-5:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-southeast-5:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-southeast-5:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-southeast-5:464622532012:layer:dd-trace-java:18"
     },
     "us-east-2": {
@@ -778,17 +836,19 @@
       "python3.13-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Python313-ARM:105",
       "ruby3.2": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Ruby3-2:24",
       "ruby3.2-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Ruby3-2-ARM:24",
+      "ruby3.3": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Ruby3-3:24",
+      "ruby3.3-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Ruby3-3-ARM:24",
       "extension": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:us-east-2:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:us-east-2:464622532012:layer:dd-trace-java:18"
     },
     "ap-southeast-7": {
       "extension": "arn:aws:lambda:ap-southeast-7:464622532012:layer:Datadog-Extension:69",
       "extension-arm": "arn:aws:lambda:ap-southeast-7:464622532012:layer:Datadog-Extension-ARM:69",
-      "dotnet": "arn:aws:lambda:ap-southeast-7:464622532012:layer:dd-trace-dotnet:18",
-      "dotnet-arm": "arn:aws:lambda:ap-southeast-7:464622532012:layer:dd-trace-dotnet-ARM:18",
+      "dotnet": "arn:aws:lambda:ap-southeast-7:464622532012:layer:dd-trace-dotnet:19",
+      "dotnet-arm": "arn:aws:lambda:ap-southeast-7:464622532012:layer:dd-trace-dotnet-ARM:19",
       "java": "arn:aws:lambda:ap-southeast-7:464622532012:layer:dd-trace-java:18"
     }
   }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Support Ruby 3.3
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Requested in https://github.com/DataDog/serverless-plugin-datadog/issues/573
<!--- What inspired you to submit this pull request? --->

### How
1. Add Ruby 3.3 to `generate_layers_json.sh`
1. Run `aws-vault exec sso-govcloud-us1-fed-engineering -- ./scripts/generate_layers_json.sh -g`
2. Run `aws-vault exec sso-prod-engineering -- ./scripts/generate_layers_json.sh`

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
