### PR TITLE
chore: Print better instructions in publish_prod.sh

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -69,7 +69,10 @@ if [ "$UPDATE_LAYERS" != "false" ]; then
 fi
 
 if [ "$UPDATE_LAYERS" != "false" ]; then
+    echo "If an SSO authorization link is printed below, please make sure to authorize it with your GovCloud account."
     aws-vault exec sso-govcloud-us1-fed-engineering -- aws sts get-caller-identity
+
+    echo "If an SSO authorization link is printed below, please make sure to authorize it with your datadoghq.com account."
     aws-vault exec sso-prod-engineering -- aws sts get-caller-identity
 
     echo "Updating layer versions for GovCloud AWS accounts"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Context
When someone runs `publish_prod.sh` to release the plugin, they will need to go through two authorizations, the first one is for GovCloud, which should be done using the GovCloud Google account; the second one is for regular prod environment, which should be done using the datadoghq.com account. Authorization will fail if a wrong account is used.

### What does this PR do?

Print instructions explaining which account should be used at each step.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
