### PR TITLE
fix: Properly handle step function trace merging when Input.$ is set

### DIFF
--- a/src/step-functions-helper.spec.ts
+++ b/src/step-functions-helper.spec.ts
@@ -350,6 +350,12 @@ describe("test updateDefinitionForStepFunctionInvocationStep", () => {
     expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
   });
 
+  it('Case 0.4: Parameters field has "Input.$" field', async () => {
+    const parameters = { FunctionName: "bla", "Input.$": "$" };
+    const step = { Parameters: parameters };
+    expect(updateDefinitionForStepFunctionInvocationStep(stepName, step, serverless, stateMachineName)).toBeFalsy();
+  });
+
   it('Case 1: Input field has stuff in it but no "CONTEXT" or "CONTEXT.$"', async () => {
     const parameters = { FunctionName: "bla", Input: { foo: "bar" } };
     const step = { Parameters: parameters };

--- a/src/step-functions-helper.ts
+++ b/src/step-functions-helper.ts
@@ -244,6 +244,7 @@ check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/\
 //  0.1 | Parameters field is not an object                        | false
 //  0.2 | Parameters field has no Input field                      | true
 //  0.3 | Parameters.Input is not an object                        | false
+//  0.4 | Parameters field has "Input.$" field                     | false
 //   1  | No "CONTEXT" or "CONTEXT.$"                              | true
 //   2  | Has "CONTEXT"                                            | false
 //  3.1 | "CONTEXT.$": "States.JsonMerge($$, $, false)" or         | false
@@ -259,6 +260,16 @@ export function updateDefinitionForStepFunctionInvocationStep(
 
   // Case 0.1: Parameters field is not an object
   if (typeof parameters !== "object") {
+    return false;
+  }
+
+  // Case 0.4: Parameters field has "Input.$" field
+  if (parameters.hasOwnProperty("Input.$")) {
+    serverless.cli
+      .log(`[Warn] Step ${stepName} of state machine ${stateMachineName} has custom "Input.$" field. Step Functions Context \
+Object injection skipped. Your Step Functions trace will not be merged with downstream Step Function traces. To manually \
+merge these traces, check out https://docs.datadoghq.com/serverless/step_functions/troubleshooting/ and \
+https://github.com/DataDog/serverless-plugin-datadog/issues/584\n`);
     return false;
   }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

In step function definition, f the user sets `"Input.$` field for a step function invocation step and sets `propagateUpstreamTrace` flag, the plugin will try to add `Input` field to merge traces, causing `serverless deploy` to fail with the error:
> Cannot have both the field 'Input.$' and the field 'Input' at the same time

See https://github.com/DataDog/serverless-plugin-datadog/issues/584

<!--- What inspired you to submit this pull request? --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

When `"Input.$` is set, do not try to set up trace merging. Instead, print a warning to direct the user to docs for manual setup.

### Testing Guidelines
1. Automated testing: Passed unit tests
2. Manual testing: Successfully deployed a stack that sets `"Input.$` field, which failed before.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
