### PR TITLE
Support Ruby 3.4

### DIFF
--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,8 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Node22-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Python313" "Datadog-Python313-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Ruby3-3" "Datadog-Ruby3-3-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs16.x" "nodejs18.x" "nodejs20.x" "nodejs22.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "python3.13" "python3.13-arm" "ruby3.2" "ruby3.2-arm" "ruby3.3" "ruby3.3-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
+LAYER_NAMES=("Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Node22-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Python313" "Datadog-Python313-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Ruby3-3" "Datadog-Ruby3-3-ARM" "Datadog-Ruby3-4" "Datadog-Ruby3-4-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
+JSON_LAYER_NAMES=("nodejs16.x" "nodejs18.x" "nodejs20.x" "nodejs22.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "python3.13" "python3.13-arm" "ruby3.2" "ruby3.2-arm" "ruby3.3" "ruby3.3-arm" "ruby3.4" "ruby3.4-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
 
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 

--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -54,6 +54,8 @@ describe("findHandlers", () => {
       "python312-function": { handler: "myfile.handler", runtime: "python3.12" },
       "python313-function": { handler: "myfile.handler", runtime: "python3.13" },
       "ruby32-function": { handler: "myfile.handler", runtime: "ruby3.2" },
+      "ruby33-function": { handler: "myfile.handler", runtime: "ruby3.3" },
+      "ruby34-function": { handler: "myfile.handler", runtime: "ruby3.4" },
       "java8-function": { handler: "myfile.handler", runtime: "java8" },
       "java8.al2-function": { handler: "myfile.handler", runtime: "java8.al2" },
       "java11-function": { handler: "myfile.handler", runtime: "java11" },
@@ -144,6 +146,18 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "ruby3.2" },
         type: RuntimeType.RUBY,
         runtime: "ruby3.2",
+      },
+      {
+        name: "ruby33-function",
+        handler: { handler: "myfile.handler", runtime: "ruby3.3" },
+        type: RuntimeType.RUBY,
+        runtime: "ruby3.3",
+      },
+      {
+        name: "ruby34-function",
+        handler: { handler: "myfile.handler", runtime: "ruby3.4" },
+        type: RuntimeType.RUBY,
+        runtime: "ruby3.4",
       },
       {
         name: "java8-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -74,7 +74,17 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "provided.al2023": RuntimeType.CUSTOM,
   provided: RuntimeType.CUSTOM,
   "ruby3.2": RuntimeType.RUBY,
+  "ruby3.2-arm": RuntimeType.RUBY,
+  "ruby3.3": RuntimeType.RUBY,
+  "ruby3.3-arm": RuntimeType.RUBY,
+  "ruby3.4": RuntimeType.RUBY,
+  "ruby3.4-arm": RuntimeType.RUBY,
   "go1.x": RuntimeType.GO,
+  extension: RuntimeType.CUSTOM,
+  "extension-arm": RuntimeType.CUSTOM,
+  dotnet: RuntimeType.DOTNET,
+  "dotnet-arm": RuntimeType.DOTNET,
+  java: RuntimeType.JAVA,
 };
 
 // Map from x86 runtime keys in layers.json to the corresponding ARM runtime keys
@@ -86,6 +96,8 @@ export const ARM_RUNTIME_KEYS: { [key: string]: string } = {
   "python3.12": "python3.12-arm",
   "python3.13": "python3.13-arm",
   "ruby3.2": "ruby3.2-arm",
+  "ruby3.3": "ruby3.3-arm",
+  "ruby3.4": "ruby3.4-arm",
   extension: "extension-arm",
   dotnet: "dotnet-arm",
   // The same Node layers work for both x86 and ARM

--- a/src/layers-gov.json
+++ b/src/layers-gov.json
@@ -22,8 +22,8 @@
       "ruby3.2-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-2-ARM:25",
       "ruby3.3": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-3:25",
       "ruby3.3-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-3-ARM:25",
-      "extension": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension:76",
-      "extension-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-ARM:76",
+      "extension": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension:77",
+      "extension-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-ARM:77",
       "dotnet": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet:20",
       "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet-ARM:20",
       "java": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-java:20"
@@ -50,8 +50,8 @@
       "ruby3.2-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-2-ARM:25",
       "ruby3.3": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-3:25",
       "ruby3.3-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-3-ARM:25",
-      "extension": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension:76",
-      "extension-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:76",
+      "extension": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension:77",
+      "extension-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:77",
       "dotnet": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet:20",
       "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet-ARM:20",
       "java": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-java:20"


### PR DESCRIPTION
This PR adds support for Ruby 3.4 runtime in the serverless plugin.