### PR TITLE
fix: Skip SFN instrumentation if compiled CFN template is unavailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -286,7 +286,8 @@ module.exports = class ServerlessPlugin {
     // See https://github.com/DataDog/serverless-plugin-datadog/issues/593
     // In that case, skip instrumenting step functions.
     if (!compiledCfnTemplate) {
-      this.serverless.cli.log("Compiled CloudFormation template not found. Skipping instrumenting step functions.");
+      this.serverless.cli.log(`Compiled CloudFormation template not found. Skipping instrumenting step functions.
+This is expected if you only deploy part of the stack.`);
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
 import * as Serverless from "serverless";
 import { FunctionDefinition } from "serverless";
 import Service from "serverless/classes/Service";
-import { Provider } from "serverless/plugins/aws/provider/awsProvider";
+import Aws, { Provider } from "serverless/plugins/aws/provider/awsProvider";
 import { version } from "../package.json";
 import { gitMetadata } from "@datadog/datadog-ci";
 import {
@@ -213,60 +213,7 @@ module.exports = class ServerlessPlugin {
         await addExecutionLogGroupsAndSubscriptions(this.serverless.service, aws, datadogForwarderArn);
       }
 
-      if (config.enableStepFunctionsTracing || config.subscribeToStepFunctionLogs) {
-        const resources = this.serverless.service.provider.compiledCloudFormationTemplate?.Resources;
-        const stepFunctions = Object.values((this.serverless.service as any).stepFunctions.stateMachines);
-        if (stepFunctions.length === 0) {
-          this.serverless.cli.log("subscribeToStepFunctionLogs is set to true but no step functions were found.");
-        } else {
-          this.serverless.cli.log("Subscribing step function log groups to Datadog Forwarder");
-          for (const stepFunction of stepFunctions as any[]) {
-            if (!stepFunction.hasOwnProperty("loggingConfig")) {
-              this.serverless.cli.log(`Creating log group for ${stepFunction.name} and logging to it with level ALL.`);
-              await addStepFunctionLogGroup(aws, resources, stepFunction);
-            } else {
-              this.serverless.cli.log(`Found logging config for step function ${stepFunction.name}`);
-              const loggingConfig = stepFunction.loggingConfig;
-
-              if (loggingConfig.level !== "ALL") {
-                loggingConfig.level = "ALL";
-                this.serverless.cli.log(
-                  `Warning: Setting log level to ALL for step function ${stepFunction.name} so traces can be generated.`,
-                );
-              }
-              if (loggingConfig.includeExecutionData !== true) {
-                loggingConfig.includeExecutionData = true;
-                this.serverless.cli.log(
-                  `Warning: Setting includeExecutionData to true for step function ${stepFunction.name} so traces can be generated.`,
-                );
-              }
-            }
-            // subscribe step function log group to datadog forwarder regardless of how the log group was created
-            await addStepFunctionLogGroupSubscription(resources, stepFunction, datadogForwarderArn);
-          }
-        }
-
-        if (config.mergeStepFunctionAndLambdaTraces || config.propagateTraceContext) {
-          this.serverless.cli.log(
-            `mergeStepFunctionAndLambdaTraces and propagateTraceContext will be deprecated. Please use propagateUpstreamTrace instead`,
-          );
-        }
-        if (config.mergeStepFunctionAndLambdaTraces || config.propagateTraceContext || config.propagateUpstreamTrace) {
-          this.serverless.cli.log(
-            `mergeStepFunctionAndLambdaTraces or propagateUpstreamTrace is true, trying to modify Step Functions' definitions to add trace context.`,
-          );
-          mergeStepFunctionAndLambdaTraces(resources, this.serverless);
-        }
-      } else {
-        // Recommend Step Functions instrumentation for customers who do not set enableStepFunctionsTracing to true
-        try {
-          inspectAndRecommendStepFunctionsInstrumentation(this.serverless);
-        } catch (error) {
-          this.serverless.cli.log(
-            `Error raise when inspecting if there are any uninstrumented Step Functions state machines. Error: ${error}`,
-          );
-        }
-      }
+      await this.instrumentStepFunctions(config, aws, datadogForwarderArn);
 
       for (const error of errors) {
         this.serverless.cli.log(error);
@@ -325,6 +272,67 @@ module.exports = class ServerlessPlugin {
       await addOutputLinks(this.serverless, config.site, config.subdomain, handlers);
     } else {
       this.serverless.cli.log("Skipped adding output links");
+    }
+  }
+
+  /**
+   * Do the major part of the work for instrumenting step functions.
+   * This function does not set tags. That is done in afterPackageCompileFunctions().
+   */
+  private async instrumentStepFunctions(config: Configuration, aws: Aws, datadogForwarderArn: string): Promise<void> {
+    if (config.enableStepFunctionsTracing || config.subscribeToStepFunctionLogs) {
+      const resources = this.serverless.service.provider.compiledCloudFormationTemplate?.Resources;
+      const stepFunctions = Object.values((this.serverless.service as any).stepFunctions.stateMachines);
+      if (stepFunctions.length === 0) {
+        this.serverless.cli.log("subscribeToStepFunctionLogs is set to true but no step functions were found.");
+      } else {
+        this.serverless.cli.log("Subscribing step function log groups to Datadog Forwarder");
+        for (const stepFunction of stepFunctions as any[]) {
+          if (!stepFunction.hasOwnProperty("loggingConfig")) {
+            this.serverless.cli.log(`Creating log group for ${stepFunction.name} and logging to it with level ALL.`);
+            await addStepFunctionLogGroup(aws, resources, stepFunction);
+          } else {
+            this.serverless.cli.log(`Found logging config for step function ${stepFunction.name}`);
+            const loggingConfig = stepFunction.loggingConfig;
+
+            if (loggingConfig.level !== "ALL") {
+              loggingConfig.level = "ALL";
+              this.serverless.cli.log(
+                `Warning: Setting log level to ALL for step function ${stepFunction.name} so traces can be generated.`,
+              );
+            }
+            if (loggingConfig.includeExecutionData !== true) {
+              loggingConfig.includeExecutionData = true;
+              this.serverless.cli.log(
+                `Warning: Setting includeExecutionData to true for step function ${stepFunction.name} so traces can be generated.`,
+              );
+            }
+          }
+          // subscribe step function log group to datadog forwarder regardless of how the log group was created
+          await addStepFunctionLogGroupSubscription(resources, stepFunction, datadogForwarderArn);
+        }
+      }
+
+      if (config.mergeStepFunctionAndLambdaTraces || config.propagateTraceContext) {
+        this.serverless.cli.log(
+          `mergeStepFunctionAndLambdaTraces and propagateTraceContext will be deprecated. Please use propagateUpstreamTrace instead`,
+        );
+      }
+      if (config.mergeStepFunctionAndLambdaTraces || config.propagateTraceContext || config.propagateUpstreamTrace) {
+        this.serverless.cli.log(
+          `mergeStepFunctionAndLambdaTraces or propagateUpstreamTrace is true, trying to modify Step Functions' definitions to add trace context.`,
+        );
+        mergeStepFunctionAndLambdaTraces(resources, this.serverless);
+      }
+    } else {
+      // Recommend Step Functions instrumentation for customers who do not set enableStepFunctionsTracing to true
+      try {
+        inspectAndRecommendStepFunctionsInstrumentation(this.serverless);
+      } catch (error) {
+        this.serverless.cli.log(
+          `Error raise when inspecting if there are any uninstrumented Step Functions state machines. Error: ${error}`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Problem

<!--- What inspired you to submit this pull request? --->

See https://github.com/DataDog/serverless-plugin-datadog/issues/593. When the user deploys only part of the stack using 
```
serverless deploy <stack-name> -s <env> --function myLambda
```

the `compiledCloudFormationTemplate` will be unavailable to the plugin, causing errors during step function instrumentation.

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

In this case, skip instrumenting step functions.

### Testing Guidelines

<!--- How did you test this pull request? --->

1. Passed the added automated test, which would fail without the fix
2. Deployed a partial stack using the steps in https://github.com/DataDog/serverless-plugin-datadog/issues/593, which would fail without the fix.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

For PR reviewers: This PR has two commits.
1. The first one just does refactoring by extracting a function
2. The second one changes the behavior

You can review them one by one.

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
