### PR TITLE
feat: Add FIPS layers to layers-gov.json

### DIFF
--- a/scripts/generate_layers_json.sh
+++ b/scripts/generate_layers_json.sh
@@ -13,8 +13,67 @@
 
 set -e
 
-LAYER_NAMES=("Datadog-Node16-x" "Datadog-Node18-x" "Datadog-Node20-x" "Datadog-Node22-x" "Datadog-Python37" "Datadog-Python38" "Datadog-Python38-ARM" "Datadog-Python39" "Datadog-Python39-ARM" "Datadog-Python310" "Datadog-Python310-ARM" "Datadog-Python311" "Datadog-Python311-ARM" "Datadog-Python312" "Datadog-Python312-ARM" "Datadog-Python313" "Datadog-Python313-ARM" "Datadog-Ruby3-2" "Datadog-Ruby3-2-ARM" "Datadog-Ruby3-3" "Datadog-Ruby3-3-ARM" "Datadog-Extension" "Datadog-Extension-ARM" "dd-trace-dotnet" "dd-trace-dotnet-ARM" "dd-trace-java")
-JSON_LAYER_NAMES=("nodejs16.x" "nodejs18.x" "nodejs20.x" "nodejs22.x" "python3.7" "python3.8" "python3.8-arm" "python3.9" "python3.9-arm" "python3.10" "python3.10-arm" "python3.11" "python3.11-arm" "python3.12" "python3.12-arm" "python3.13" "python3.13-arm" "ruby3.2" "ruby3.2-arm" "ruby3.3" "ruby3.3-arm" "extension" "extension-arm" "dotnet" "dotnet-arm" "java")
+LAYER_NAMES=(
+    "Datadog-Node16-x"
+    "Datadog-Node18-x"
+    "Datadog-Node20-x"
+    "Datadog-Node22-x"
+    "Datadog-Python37"
+    "Datadog-Python38"
+    "Datadog-Python38-ARM"
+    "Datadog-Python39"
+    "Datadog-Python39-ARM"
+    "Datadog-Python310"
+    "Datadog-Python310-ARM"
+    "Datadog-Python311"
+    "Datadog-Python311-ARM"
+    "Datadog-Python312"
+    "Datadog-Python312-ARM"
+    "Datadog-Python313"
+    "Datadog-Python313-ARM"
+    "Datadog-Ruby3-2"
+    "Datadog-Ruby3-2-ARM"
+    "Datadog-Ruby3-3"
+    "Datadog-Ruby3-3-ARM"
+    "Datadog-Extension"
+    "Datadog-Extension-ARM"
+    "Datadog-Extension-FIPS"
+    "Datadog-Extension-ARM-FIPS"
+    "dd-trace-dotnet"
+    "dd-trace-dotnet-ARM"
+    "dd-trace-java"
+)
+
+JSON_LAYER_NAMES=(
+    "nodejs16.x"
+    "nodejs18.x"
+    "nodejs20.x"
+    "nodejs22.x"
+    "python3.7"
+    "python3.8"
+    "python3.8-arm"
+    "python3.9"
+    "python3.9-arm"
+    "python3.10"
+    "python3.10-arm"
+    "python3.11"
+    "python3.11-arm"
+    "python3.12"
+    "python3.12-arm"
+    "python3.13"
+    "python3.13-arm"
+    "ruby3.2"
+    "ruby3.2-arm"
+    "ruby3.3"
+    "ruby3.3-arm"
+    "extension"
+    "extension-arm"
+    "extension-fips"
+    "extension-arm-fips"
+    "dotnet"
+    "dotnet-arm"
+    "java"
+)
 
 AVAILABLE_REGIONS=$(aws ec2 describe-regions | jq -r '.[] | .[] | .RegionName')
 

--- a/src/layers-gov.json
+++ b/src/layers-gov.json
@@ -24,6 +24,8 @@
       "ruby3.3-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Ruby3-3-ARM:25",
       "extension": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension:78",
       "extension-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-ARM:78",
+      "extension-fips": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-FIPS:78",
+      "extension-arm-fips": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:Datadog-Extension-ARM-FIPS:78",
       "dotnet": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet:20",
       "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-dotnet-ARM:20",
       "java": "arn:aws-us-gov:lambda:us-gov-west-1:002406178527:layer:dd-trace-java:21"
@@ -52,6 +54,8 @@
       "ruby3.3-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Ruby3-3-ARM:25",
       "extension": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension:78",
       "extension-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM:78",
+      "extension-fips": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-FIPS:78",
+      "extension-arm-fips": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Extension-ARM-FIPS:78",
       "dotnet": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet:20",
       "dotnet-arm": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-dotnet-ARM:20",
       "java": "arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:dd-trace-java:21"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

1. In `generate_layers_json.sh`, add layer names `Datadog-Extension-FIPS` and `Datadog-Extension-ARM-FIPS` so the FIPS layers for GovCloud can be added to `layers-gov.json`
2. Reformat the lists `LAYER_NAMES` and `JSON_LAYER_NAMES`. Make each value have a single line for better readability.

### Motivation

<!--- What inspired you to submit this pull request? --->

This is the first step towards supporting FIPS in Serverless Plugin.

### Testing Guidelines

<!--- How did you test this pull request? --->

Run `aws-vault exec sso-govcloud-us1-fed-engineering -- ./scripts/generate_layers_json.sh -g`, which updates `layers-gov.json`.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

The next PR will add a parameter to allow choosing the FIPS layer.

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
