### PR TITLE
Bug in datadog API recommended monitor template: high throttle

### DIFF
--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -788,7 +788,7 @@ describe("getRecommendedMonitors", () => {
       "avg(last_15m):min:aws.lambda.iterator_age.maximum{aws_cloudformation_stack-id:cloudformation_stackid} by {aws_account,region,functionname} >= 1000",
     );
     expect(response.high_throttles.query("cloudformation_stackid", 0.1)).toEqual(
-      "sum(last_15m):sum:aws.lambda.throttles {aws_cloudformation_stack-id:cloudformation_stackid} by {aws_account,region,functionname}.as_count() / ( sum:aws.lambda.throttles {aws_cloudformation_stack-id:cloudformation_stackid} by {aws_account,region,functionname}.as_count() + sum:aws.lambda.invocations{aws_cloudformation_stack-id:aws_cloudformation_stack-id:cloudformation_stackid} by {aws_account,region,functionname}.as_count()) >= 0.1",
+      "sum(last_15m):sum:aws.lambda.throttles {aws_cloudformation_stack-id:cloudformation_stackid} by {aws_account,region,functionname}.as_count() / ( sum:aws.lambda.throttles {aws_cloudformation_stack-id:cloudformation_stackid} by {aws_account,region,functionname}.as_count() + sum:aws.lambda.invocations{aws_cloudformation_stack-id:cloudformation_stackid} by {aws_account,region,functionname}.as_count()) >= 0.1",
     );
 
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -206,7 +206,10 @@ export async function getRecommendedMonitors(
       query: (cloudFormationStackId: string, criticalThreshold: number) => {
         let query = recommendedMonitorParam.attributes.query;
         // replace $scope with cloudformation_stack_id
-        query = query.replace(/aws_cloudformation_stack-id:\$scope/g, `aws_cloudformation_stack-id:${cloudFormationStackId}`);
+        query = query.replace(
+          /aws_cloudformation_stack-id:\$scope/g,
+          `aws_cloudformation_stack-id:${cloudFormationStackId}`,
+        );
         query = query.replace(/\$scope/g, `aws_cloudformation_stack-id:${cloudFormationStackId}`);
 
         if (criticalThreshold !== recommendedMonitorParam.attributes.options.thresholds.critical) {

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -206,6 +206,7 @@ export async function getRecommendedMonitors(
       query: (cloudFormationStackId: string, criticalThreshold: number) => {
         let query = recommendedMonitorParam.attributes.query;
         // replace $scope with cloudformation_stack_id
+        query = query.replace(/aws_cloudformation_stack-id:\$scope/g, `aws_cloudformation_stack-id:${cloudFormationStackId}`);
         query = query.replace(/\$scope/g, `aws_cloudformation_stack-id:${cloudFormationStackId}`);
 
         if (criticalThreshold !== recommendedMonitorParam.attributes.options.thresholds.critical) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fix for recommended monitor, High Throttles template, that is returned from the datadog API when calling this endpoint: https://api.${site}/api/v2/monitor/recommended?count=50&start=0&search=tag%3A%22product%3Aserverless%22%20AND%20tag%3A%22integration%3Aamazon-lambda%22

High Throttle template metric query (second in the template) for `aws.lambda.invocations`, "incorrectly" contains `aws_cloudformation_stack-id:$scope`, where the plugin expects to replace only the `$scope` string with the CloudFormation Stack ID. 

Resulting datadog query is then incorrect with `aws_cloudformation_stack-id` as part of the resource name. This is incorrect and should just be the arn of the CloudFormation Stack.

`sum:aws.lambda.invocations{aws_cloudformation_stack-id:aws_cloudformation_stack-id:arn:aws:cloudformation:us-west-2:*******:stack/my-stack/38ba2dc0-....} by {aws_account,region,functionname}.as_count()`

Correct query SHOULD be:

 `sum:aws.lambda.invocations{aws_cloudformation_stack-id:arn:aws:cloudformation:us-west-2:*******:stack/my-stack/38ba2dc0-....} by {aws_account,region,functionname}.as_count()`

### Motivation

High Throttles monitors are incorrect and not working.

### Testing Guidelines

Ran existing unit tests. Found unit test to also be incorrect checking for `aws_cloudformation_stack-id:aws_cloudformation_stack-id:arn-***` instead of just `aws_cloudformation_stack-id:arn-***`

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
