### PR TITLE
Add LLM Observability env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ To further configure your plugin, use the following custom parameters in your `s
 | `propagateUpstreamTrace` | When set to `true`, downstream Stepfunction invocation traces merge with upstream Stepfunction invocations. Defaults to `false`. |
 | `redirectHandlers`    | Optionally disable handler redirection if set to `false`. This should only be set to `false` when APM is fully disabled. Defaults to `true`.                                                                                                                                                                  |
 | `isFIPSEnabled`    |  When set to `true`, a FIPS-compliant Lambda extension layer is used. This only works if `addExtension` is `true`. Defaults to `true` if `addExtension` is `true`, and AWS region starts with `us-gov-`. Defaults to `false` otherwise.                                                                                                                                                                  |
+| `llmObsEnabled`            | Toggle to enable submitting data to LLM Observability. Defaults to `false`. |
+| `llmObsMlApp`              | The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](https://docs.datadoghq.com/llm_observability/sdk/?tab=nodejs#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given root span, see [Tracing multiple applications](https://docs.datadoghq.com/llm_observability/sdk/?tab=nodejs#tracing-multiple-applications).  Required if `llmObsEnabled` is `true` |
+| `llmObsAgentlessEnabled`   | Only required if you are not using the Datadog Agent, in which case this should be set to `true`.  Defaults to `false`. |
+
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 
 ```yaml

--- a/src/env.spec.ts
+++ b/src/env.spec.ts
@@ -999,6 +999,157 @@ describe("setEnvConfiguration", () => {
     ]);
   });
 
+  it("sets LLM Observability environment variables", () => {
+    const handlers: FunctionInfo[] = [
+      {
+        handler: {
+          environment: {},
+          events: [],
+        },
+        name: "function",
+        type: RuntimeType.NODE,
+      },
+    ];
+    setEnvConfiguration(
+      {
+        addLayers: false,
+        apiKey: "1234",
+        apiKMSKey: "5678",
+        site: "datadoghq.eu",
+        subdomain: "app",
+        logLevel: "info",
+        flushMetricsToLogs: true,
+        enableXrayTracing: true,
+        enableDDTracing: true,
+        enableDDLogs: true,
+        subscribeToAccessLogs: true,
+        subscribeToExecutionLogs: false,
+        subscribeToStepFunctionLogs: false,
+        addExtension: true,
+        enableTags: true,
+        injectLogContext: false,
+        exclude: ["dd-excluded-function"],
+        enableSourceCodeIntegration: true,
+        uploadGitMetadata: false,
+        failOnError: false,
+        skipCloudformationOutputs: false,
+        llmObsEnabled: true,
+        llmObsMlApp: "my-llm-app",
+        llmObsAgentlessEnabled: false,
+      },
+      handlers,
+    );
+    expect(handlers).toEqual([
+      {
+        handler: {
+          environment: {
+            DD_API_KEY: "1234",
+            DD_KMS_API_KEY: "5678",
+            DD_LOGS_INJECTION: false,
+            DD_SERVERLESS_LOGS_ENABLED: true,
+            DD_LOG_LEVEL: "info",
+            DD_SITE: "datadoghq.eu",
+            DD_TRACE_ENABLED: true,
+            DD_MERGE_XRAY_TRACES: true,
+            DD_LLMOBS_ENABLED: true,
+            DD_LLMOBS_ML_APP: "my-llm-app",
+            DD_LLMOBS_AGENTLESS_ENABLED: false,
+          },
+          events: [],
+        },
+        name: "function",
+        type: RuntimeType.NODE,
+      },
+    ]);
+  });
+
+  it("throws error when `llmObsEnabled` is true but `llmObsMlApp` is not set", () => {
+    const handlers: FunctionInfo[] = [
+      {
+        handler: {
+          environment: {},
+          events: [],
+        },
+        name: "function",
+        type: RuntimeType.NODE,
+      },
+    ];
+    expect(() => {
+      setEnvConfiguration(
+        {
+          addLayers: false,
+          apiKey: "1234",
+          apiKMSKey: "5678",
+          site: "datadoghq.eu",
+          subdomain: "app",
+          logLevel: "info",
+          flushMetricsToLogs: true,
+          enableXrayTracing: true,
+          enableDDTracing: true,
+          enableDDLogs: true,
+          subscribeToAccessLogs: true,
+          subscribeToExecutionLogs: false,
+          subscribeToStepFunctionLogs: false,
+          addExtension: true,
+          enableTags: true,
+          injectLogContext: false,
+          exclude: ["dd-excluded-function"],
+          enableSourceCodeIntegration: true,
+          uploadGitMetadata: false,
+          failOnError: false,
+          skipCloudformationOutputs: false,
+          llmObsEnabled: true,
+        },
+        handlers,
+      );
+    }).toThrowError("When `llmObsEnabled` is true, `llmObsMlApp` must also be set.");
+  });
+
+  it("throws error when `llmObsMlApp` is set to an invalid value", () => {
+    const handlers: FunctionInfo[] = [
+      {
+        handler: {
+          environment: {},
+          events: [],
+        },
+        name: "function",
+        type: RuntimeType.NODE,
+      },
+    ];
+    expect(() => {
+      setEnvConfiguration(
+        {
+          addLayers: false,
+          apiKey: "1234",
+          apiKMSKey: "5678",
+          site: "datadoghq.eu",
+          subdomain: "app",
+          logLevel: "info",
+          flushMetricsToLogs: true,
+          enableXrayTracing: true,
+          enableDDTracing: true,
+          enableDDLogs: true,
+          subscribeToAccessLogs: true,
+          subscribeToExecutionLogs: false,
+          subscribeToStepFunctionLogs: false,
+          addExtension: true,
+          enableTags: true,
+          injectLogContext: false,
+          exclude: ["dd-excluded-function"],
+          enableSourceCodeIntegration: true,
+          uploadGitMetadata: false,
+          failOnError: false,
+          skipCloudformationOutputs: false,
+          llmObsEnabled: true,
+          llmObsMlApp: "NO-YELLING!!!",
+        },
+        handlers,
+      );
+    }).toThrowError(
+      "`llmObsMlApp` must be only contain up to 193 alphanumeric characters, hyphens, underscores, periods, and slashes.",
+    );
+  });
+
   it("throws error when trying to add `DD_API_KEY_SECRET_ARN` while using sync metrics in a node runtime", () => {
     const handlers: FunctionInfo[] = [
       {


### PR DESCRIPTION
### What does this PR do?

Add the LLM observability env vars in line with their description.  This PR is largely a copy / paste of https://github.com/DataDog/datadog-cdk-constructs/pull/451

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

1. Created a sample serverless plugin app, deployed the stack
2. Added the environment variables and relinked them according to the [contributing guide](https://github.com/DataDog/serverless-plugin-datadog/blob/main/CONTRIBUTING.md).
3. Deployed the stack again, no changes.
4. Added the following env vars to my test app

```
    llmObsEnabled: true
    llmObsMlApp: alex-test
    llmObsAgentlessEnabled: true
```

5. Deployed the changes
6. Checked in AWS for the environment variables, confirmed just those 3 were added

<img width="1320" height="690" alt="image" src="https://github.com/user-attachments/assets/1cbb4a9d-afb5-49ca-80ce-62c1b1b214ee" />


### Additional Notes

* Docs: https://docs.datadoghq.com/llm_observability/sdk/?tab=nodejs#command-line-setup
* JIRA: https://datadoghq.atlassian.net/browse/SVLS-7054

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
