### PR TITLE
Update README to say lambda extension instead of Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To further configure your plugin, use the following custom parameters in your `s
 | `isFIPSEnabled`    |  When set to `true`, a FIPS-compliant Lambda extension layer is used. This only works if `addExtension` is `true`. Defaults to `true` if `addExtension` is `true`, and AWS region starts with `us-gov-`. Defaults to `false` otherwise.                                                                                                                                                                  |
 | `llmObsEnabled`            | Toggle to enable submitting data to LLM Observability. Defaults to `false`. |
 | `llmObsMlApp`              | The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](https://docs.datadoghq.com/llm_observability/sdk/?tab=nodejs#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given root span, see [Tracing multiple applications](https://docs.datadoghq.com/llm_observability/sdk/?tab=nodejs#tracing-multiple-applications).  Required if `llmObsEnabled` is `true` |
-| `llmObsAgentlessEnabled`   | Only required if you are not using the Datadog Agent, in which case this should be set to `true`.  Defaults to `false`. |
+| `llmObsAgentlessEnabled`   | Only required if you are not using the Datadog Lambda Extension, in which case this should be set to `true`.  Defaults to `false`. |
 
 To use any of these parameters, add a `custom` > `datadog` section to your `serverless.yml` similar to this example:
 


### PR DESCRIPTION
### What does this PR do?
Jordan pointed out in this PR that the lambda extension is more accurate than agent here.

* Other PR: https://github.com/DataDog/datadog-cloudformation-macro/pull/205

* JIRA: https://datadoghq.atlassian.net/browse/SVLS-7054

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
