### PR TITLE
feat: Print error detail when monitor API returns 400

### DIFF
--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -114,9 +114,15 @@ describe("createMonitor", () => {
     );
   });
   it("returns an Error", async () => {
-    (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
+    (fetch as unknown as jest.Mock).mockReturnValue({
+      status: 403,
+      statusText: "Unauthorized",
+      text: jest.fn().mockResolvedValue("Mock response text"),
+    });
     const response = await createMonitor("datadoghq.com", monitorParams, "apikey", "appkey");
-    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow("403 Unauthorized");
+    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow(
+      "403 Unauthorized: Mock response text",
+    );
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor",
@@ -165,9 +171,15 @@ describe("updateMonitor", () => {
     );
   });
   it("throws an Invalid Authentication Error when authentication is invalid", async () => {
-    (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
+    (fetch as unknown as jest.Mock).mockReturnValue({
+      status: 403,
+      statusText: "Unauthorized",
+      text: jest.fn().mockResolvedValue("Mock response text"),
+    });
     const response = await updateMonitor("datadoghq.com", 12345, monitorParams, "apikey", "appkey");
-    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow("403 Unauthorized");
+    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow(
+      "403 Unauthorized: Mock response text",
+    );
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor/12345",
@@ -194,9 +206,15 @@ describe("deleteMonitor", () => {
     );
   });
   it("returns false and throws an Error", async () => {
-    (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
+    (fetch as unknown as jest.Mock).mockReturnValue({
+      status: 403,
+      statusText: "Unauthorized",
+      text: jest.fn().mockResolvedValue("Mock response text"),
+    });
     const response = await deleteMonitor("datadoghq.com", 12345, "apikey", "appkey");
-    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow("403 Unauthorized");
+    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow(
+      "403 Unauthorized: Mock response text",
+    );
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor/12345",

--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -99,12 +99,13 @@ describe("createMonitor", () => {
     );
   });
   it("returns false and logs a 400 Bad Request when syntax is invalid", async () => {
-    (fetch as unknown as jest.Mock).mockReturnValue({ status: 400 });
+    (fetch as unknown as jest.Mock).mockReturnValue({
+      status: 400,
+      text: jest.fn().mockResolvedValue("Mock response text"),
+    });
     const response = await createMonitor("datadoghq.com", invalidMonitorParams, "apikey", "appkey");
-    expect(
-      async () => await handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com"),
-    ).toThrowError(
-      "400 Bad Request: This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies",
+    await expect(handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com")).rejects.toThrow(
+      "400 Bad Request: Mock response text. This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies",
     );
     expect(response.status).toBe(400);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
@@ -115,7 +116,7 @@ describe("createMonitor", () => {
   it("returns an Error", async () => {
     (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
     const response = await createMonitor("datadoghq.com", monitorParams, "apikey", "appkey");
-    expect(async () => await handleMonitorsApiResponse(response, "high_error_rate")).toThrowError("403 Unauthorized");
+    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow("403 Unauthorized");
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor",
@@ -149,12 +150,13 @@ describe("updateMonitor", () => {
   });
   it("returns false and logs 400 Bad Request when syntax is invalid", async () => {
     console.log = jest.fn();
-    (fetch as unknown as jest.Mock).mockReturnValue({ status: 400 });
+    (fetch as unknown as jest.Mock).mockReturnValue({
+      status: 400,
+      text: jest.fn().mockResolvedValue("Mock response text"),
+    });
     const response = await updateMonitor("datadoghq.com", 12345, invalidMonitorParams, "apikey", "appkey");
-    expect(
-      async () => await handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com"),
-    ).toThrowError(
-      "400 Bad Request: This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies",
+    await expect(handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com")).rejects.toThrow(
+      "400 Bad Request: Mock response text. This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies",
     );
     expect(response.status).toBe(400);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
@@ -165,7 +167,7 @@ describe("updateMonitor", () => {
   it("throws an Invalid Authentication Error when authentication is invalid", async () => {
     (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
     const response = await updateMonitor("datadoghq.com", 12345, monitorParams, "apikey", "appkey");
-    expect(async () => await handleMonitorsApiResponse(response, "high_error_rate")).toThrowError("403 Unauthorized");
+    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow("403 Unauthorized");
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor/12345",
@@ -194,7 +196,7 @@ describe("deleteMonitor", () => {
   it("returns false and throws an Error", async () => {
     (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
     const response = await deleteMonitor("datadoghq.com", 12345, "apikey", "appkey");
-    expect(() => handleMonitorsApiResponse(response, "high_error_rate")).toThrowError("403 Unauthorized");
+    await expect(handleMonitorsApiResponse(response, "high_error_rate")).rejects.toThrow("403 Unauthorized");
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor/12345",

--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -101,7 +101,9 @@ describe("createMonitor", () => {
   it("returns false and logs a 400 Bad Request when syntax is invalid", async () => {
     (fetch as unknown as jest.Mock).mockReturnValue({ status: 400 });
     const response = await createMonitor("datadoghq.com", invalidMonitorParams, "apikey", "appkey");
-    expect(() => handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com")).toThrowError(
+    expect(
+      async () => await handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com"),
+    ).toThrowError(
       "400 Bad Request: This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies",
     );
     expect(response.status).toBe(400);
@@ -113,7 +115,7 @@ describe("createMonitor", () => {
   it("returns an Error", async () => {
     (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
     const response = await createMonitor("datadoghq.com", monitorParams, "apikey", "appkey");
-    expect(() => handleMonitorsApiResponse(response, "high_error_rate")).toThrowError("403 Unauthorized");
+    expect(async () => await handleMonitorsApiResponse(response, "high_error_rate")).toThrowError("403 Unauthorized");
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor",
@@ -149,7 +151,9 @@ describe("updateMonitor", () => {
     console.log = jest.fn();
     (fetch as unknown as jest.Mock).mockReturnValue({ status: 400 });
     const response = await updateMonitor("datadoghq.com", 12345, invalidMonitorParams, "apikey", "appkey");
-    expect(() => handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com")).toThrowError(
+    expect(
+      async () => await handleMonitorsApiResponse(response, "high_error_rate", "app", "datadoghq.com"),
+    ).toThrowError(
       "400 Bad Request: This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies",
     );
     expect(response.status).toBe(400);
@@ -161,7 +165,7 @@ describe("updateMonitor", () => {
   it("throws an Invalid Authentication Error when authentication is invalid", async () => {
     (fetch as unknown as jest.Mock).mockReturnValue({ status: 403, statusText: "Unauthorized" });
     const response = await updateMonitor("datadoghq.com", 12345, monitorParams, "apikey", "appkey");
-    expect(() => handleMonitorsApiResponse(response, "high_error_rate")).toThrowError("403 Unauthorized");
+    expect(async () => await handleMonitorsApiResponse(response, "high_error_rate")).toThrowError("403 Unauthorized");
     expect(response.status).toBe(403);
     expect(fetch as unknown as jest.Mock).toHaveBeenCalledWith(
       "https://api.datadoghq.com/api/v1/monitor/12345",

--- a/src/monitors.ts
+++ b/src/monitors.ts
@@ -165,7 +165,8 @@ export async function handleMonitorsApiResponse(
       `400 Bad Request: ${response_text}. This could be due to incorrect syntax or a missing required tag for ${serverlessMonitorId}. Have you looked at your monitor tag policies? https://${subdomain}.${site}/monitors/settings/policies`,
     );
   } else {
-    throw new Error(`${response.status} ${response.statusText}`);
+    const response_text = await response.text();
+    throw new Error(`${response.status} ${response.statusText}: ${response_text}`);
   }
 }
 

--- a/src/monitors.ts
+++ b/src/monitors.ts
@@ -134,7 +134,7 @@ async function deleteRemovedMonitors(
   for (const pluginMonitorId of Object.keys(existingMonitors)) {
     if (!currentMonitorIds.includes(pluginMonitorId)) {
       const response = await deleteMonitor(site, existingMonitors[pluginMonitorId], monitorsApiKey, monitorsAppKey);
-      const successfullyDeleted = handleMonitorsApiResponse(response, pluginMonitorId);
+      const successfullyDeleted = await handleMonitorsApiResponse(response, pluginMonitorId);
       if (successfullyDeleted) {
         successfullyDeletedMonitors.push(` ${pluginMonitorId}`);
       }
@@ -151,17 +151,18 @@ async function deleteRemovedMonitors(
  * @param site Which Datadog site to send data to, e.g. datadoghq.com
  * @returns true if the response is 200 OK. Throw an error for other HTTP status codes.
  */
-export function handleMonitorsApiResponse(
+export async function handleMonitorsApiResponse(
   response: Response,
   serverlessMonitorId?: string,
   subdomain?: string,
   site?: string,
-): boolean {
+): Promise<boolean> {
   if (response.status === 200) {
     return true;
   } else if (response.status === 400) {
+    const response_text = await response.text();
     throw new Error(
-      `400 Bad Request: This could be due to incorrect syntax or a missing required tag for ${serverlessMonitorId}. Have you looked at your monitor tag policies? https://${subdomain}.${site}/monitors/settings/policies`,
+      `400 Bad Request: ${response_text}. This could be due to incorrect syntax or a missing required tag for ${serverlessMonitorId}. Have you looked at your monitor tag policies? https://${subdomain}.${site}/monitors/settings/policies`,
     );
   } else {
     throw new Error(`${response.status} ${response.statusText}`);
@@ -209,13 +210,13 @@ export async function setMonitors(
     const monitorExists = await doesMonitorExist(serverlessMonitorId, serverlessMonitorIdByMonitorId);
     if (monitorExists) {
       const response = await updateMonitor(site, monitorIdNumber, monitorParams, monitorsApiKey, monitorsAppKey);
-      const successfullyCreated = handleMonitorsApiResponse(response, serverlessMonitorId, subdomain, site);
+      const successfullyCreated = await handleMonitorsApiResponse(response, serverlessMonitorId, subdomain, site);
       if (successfullyCreated) {
         successfullyUpdatedMonitors.push(` ${serverlessMonitorId}`);
       }
     } else {
       const response = await createMonitor(site, monitorParams, monitorsApiKey, monitorsAppKey);
-      const successfullyUpdated = handleMonitorsApiResponse(response, serverlessMonitorId, subdomain, site);
+      const successfullyUpdated = await handleMonitorsApiResponse(response, serverlessMonitorId, subdomain, site);
       if (successfullyUpdated) {
         successfullyCreatedMonitors.push(` ${serverlessMonitorId}`);
       }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

<!--- What inspired you to submit this pull request? --->

Right now, when monitor creations fails, the plugin will print:
> Error occurred when configuring monitors: 400 Bad Request: This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies

This only includes the HTTP status code, but not the details of the error. This part:
> This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies

is just a general suggestion we print for all 400 responses.

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

In case of 400 (and other non-200 responses), also print the response text like:
> {"errors":["Missing required tag key(s): team"]}

### Testing Guidelines

<!--- How did you test this pull request? --->

Deploy a Lambda with a misconfigured monitor, and this message is printed:

> Error occurred when configuring monitors: 400 Bad Request: {"errors":["Missing required tag key(s): team"]}. This could be due to incorrect syntax or a missing required tag for high_error_rate. Have you looked at your monitor tag policies? https://app.datadoghq.com/monitors/settings/policies

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
