### PR TITLE
chore: Move ci to node 20 and 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        node-version: [18, 22]
+        node-version: [20, 22]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

This PR updates CI to use node 20 and node 22 instead of node 18 and node 22. 

### Motivation

<!--- What inspired you to submit this pull request? --->

- Node 18 is deprecated
- I'd like to bump `datadog-ci` to the latest version, which uses `@azure/identity 4.10.2` which requires a minimum node version of `20.0.0`. See failing checks on https://github.com/DataDog/serverless-plugin-datadog/pull/606. 

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
