### PR TITLE
Add `ruby3.3` to the runtime lookup tables

### DIFF
--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -54,6 +54,7 @@ describe("findHandlers", () => {
       "python312-function": { handler: "myfile.handler", runtime: "python3.12" },
       "python313-function": { handler: "myfile.handler", runtime: "python3.13" },
       "ruby32-function": { handler: "myfile.handler", runtime: "ruby3.2" },
+      "ruby33-function": { handler: "myfile.handler", runtime: "ruby3.3" },
       "java8-function": { handler: "myfile.handler", runtime: "java8" },
       "java8.al2-function": { handler: "myfile.handler", runtime: "java8.al2" },
       "java11-function": { handler: "myfile.handler", runtime: "java11" },
@@ -144,6 +145,12 @@ describe("findHandlers", () => {
         handler: { handler: "myfile.handler", runtime: "ruby3.2" },
         type: RuntimeType.RUBY,
         runtime: "ruby3.2",
+      },
+      {
+        name: "ruby33-function",
+        handler: { handler: "myfile.handler", runtime: "ruby3.3" },
+        type: RuntimeType.RUBY,
+        runtime: "ruby3.3",
       },
       {
         name: "java8-function",

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -77,6 +77,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "provided.al2023": RuntimeType.CUSTOM,
   provided: RuntimeType.CUSTOM,
   "ruby3.2": RuntimeType.RUBY,
+  "ruby3.3": RuntimeType.RUBY,
   "go1.x": RuntimeType.GO,
 };
 
@@ -89,6 +90,7 @@ export const ARM_RUNTIME_KEYS: { [key: string]: string } = {
   "python3.12": "python3.12-arm",
   "python3.13": "python3.13-arm",
   "ruby3.2": "ruby3.2-arm",
+  "ruby3.3": "ruby3.3-arm",
   extension: "extension-arm",
   dotnet: "dotnet-arm",
   // The same Node layers work for both x86 and ARM


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Added `ruby3.3` as a supported runtime in the runtime lookup tables, such that it resolves to the `RUBY` runtime type

### Motivation

I need to use this plugin with my Lambda using the Ruby 3.3 runtime

### Testing Guidelines

- Updated unit test

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
