### PR TITLE
Pin version of Datadog-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "@datadog/datadog-ci": "^3.17.0",
+    "@datadog/datadog-ci": "3.17.0",
     "node-fetch": "^2.6.1",
     "simple-git": "^3.16.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,7 +1079,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@datadog/datadog-ci@^3.17.0":
+"@datadog/datadog-ci@3.17.0":
   version "3.17.0"
   resolved "https://registry.yarnpkg.com/@datadog/datadog-ci/-/datadog-ci-3.17.0.tgz#d3542c4d318d2c26c5027012ba0f4c22a6c2f2b3"
   integrity sha512-tKMTmB2TRVavIcAbCVtfyhFCgGO4+qSfRxT/ogkZ0T6VB70y8qPzFUlmka4WSDclPnBO5IRafzYNmzjmT5F6vg==


### PR DESCRIPTION
# Notes
Pin the version of datadog-ci to the min that we previously allowed.  This is to mitigate an issue with the datadog-ci package migration breaking the imports.

Github issue:https://github.com/DataDog/serverless-plugin-datadog/issues/612

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
