### PR TITLE
[CHORE] use builtin fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "@datadog/datadog-ci": "3.21.4",
-    "node-fetch": "^2.6.1",
     "simple-git": "^3.16.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/mock-fs": "4.13.0",
-    "@types/node-fetch": "^2.5.10",
     "@types/serverless": "3.12.27",
     "jest": "^29.7.0",
     "jest-environment-node": "^30.2.0",

--- a/src/monitor-api-requests.spec.ts
+++ b/src/monitor-api-requests.spec.ts
@@ -1,4 +1,3 @@
-import fetch from "node-fetch";
 import {
   createMonitor,
   updateMonitor,
@@ -10,7 +9,9 @@ import {
 } from "./monitor-api-requests";
 import { MonitorParams, handleMonitorsApiResponse } from "./monitors";
 
-jest.mock("node-fetch");
+beforeAll(() => {
+  global.fetch = jest.fn();
+});
 
 const monitorParams: MonitorParams = {
   tags: [

--- a/src/monitor-api-requests.ts
+++ b/src/monitor-api-requests.ts
@@ -1,4 +1,3 @@
-import fetch, { Response } from "node-fetch";
 import * as Serverless from "serverless";
 import { MonitorParams, ServerlessMonitor, replaceCriticalThreshold } from "./monitors";
 
@@ -44,7 +43,7 @@ export async function createMonitor(
   monitorsApiKey: string,
   monitorsAppKey: string,
 ): Promise<Response> {
-  const response: Response = await fetch(`https://api.${site}/api/v1/monitor`, {
+  const response = await fetch(`https://api.${site}/api/v1/monitor`, {
     method: "POST",
     headers: {
       "DD-API-KEY": monitorsApiKey,
@@ -63,7 +62,7 @@ export async function updateMonitor(
   monitorsApiKey: string,
   monitorsAppKey: string,
 ): Promise<Response> {
-  const response: Response = await fetch(`https://api.${site}/api/v1/monitor/${monitorId}`, {
+  const response = await fetch(`https://api.${site}/api/v1/monitor/${monitorId}`, {
     method: "PUT",
     headers: {
       "DD-API-KEY": monitorsApiKey,
@@ -82,7 +81,7 @@ export async function deleteMonitor(
   monitorsApiKey: string,
   monitorsAppKey: string,
 ): Promise<Response> {
-  const response: Response = await fetch(`https://api.${site}/api/v1/monitor/${monitorId}`, {
+  const response = await fetch(`https://api.${site}/api/v1/monitor/${monitorId}`, {
     method: "DELETE",
     headers: {
       "DD-API-KEY": monitorsApiKey,
@@ -105,7 +104,7 @@ export async function searchMonitors(
   let pageCount = 1;
   do {
     const query = `tag:"${queryTag}"`;
-    const response: Response = await fetch(`https://api.${site}/api/v1/monitor/search?query=${query}&page=${page}`, {
+    const response = await fetch(`https://api.${site}/api/v1/monitor/search?query=${query}&page=${page}`, {
       method: "GET",
       headers: {
         "DD-API-KEY": monitorsApiKey,
@@ -118,7 +117,7 @@ export async function searchMonitors(
       throw new Error(`Can't fetch monitors. Status code: ${response.status}. Message: ${response.statusText}`);
     }
 
-    const json = await response.json();
+    const json: any = await response.json(); // TODO: use proper type/parsing
     monitors = monitors.concat(json.monitors);
     pageCount = json.metadata.page_count;
     page += 1;
@@ -178,7 +177,7 @@ export async function getRecommendedMonitors(
   const recommendedMonitors: { [key: string]: ServerlessMonitor } = {};
   // Setting a count of 50 in the hope that all can be fetched at once. The default is 10 per page.
   const endpoint = `https://api.${site}/api/v2/monitor/recommended?count=50&start=0&search=tag%3A%22product%3Aserverless%22%20AND%20tag%3A%22integration%3Aamazon-lambda%22`;
-  const response: Response = await fetch(endpoint, {
+  const response = await fetch(endpoint, {
     method: "GET",
     headers: {
       "DD-API-KEY": monitorsApiKey,
@@ -190,7 +189,7 @@ export async function getRecommendedMonitors(
     throw new Error(`Can't fetch monitor params. Status code: ${response.status}. Message: ${response.statusText}`);
   }
 
-  const json = await response.json();
+  const json: any = await response.json(); // TODO: use proper type/parsing
   const recommendedMonitorsData = json.data;
   recommendedMonitorsData.forEach((recommendedMonitorParam: RecommendedMonitorParams) => {
     const recommendedMonitorId = parseRecommendedMonitorServerlessId(recommendedMonitorParam);

--- a/src/monitors.ts
+++ b/src/monitors.ts
@@ -6,7 +6,6 @@ import {
   getRecommendedMonitors,
   TemplateVariable,
 } from "./monitor-api-requests";
-import { Response } from "node-fetch";
 
 export interface MonitorParams {
   [key: string]: any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5679,7 +5679,7 @@ node-domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@^2.6.1, node-fetch@^2.6.11, node-fetch@^2.6.9, node-fetch@^2.7.0:
+node-fetch@^2.6.11, node-fetch@^2.6.9, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/serverless-plugin-datadog/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Uses the built in `fetch()` function in node rather than using `node-fetch`

### Motivation

<!--- What inspired you to submit this pull request? --->
https://github.com/DataDog/serverless-plugin-datadog/pull/621

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
