### PR TITLE
Fix integration test failing on first Dependabot PR run

### DIFF
--- a/integration_tests/offline.js
+++ b/integration_tests/offline.js
@@ -17,6 +17,12 @@
  * synthetic "does not exist" error, which the Serverless handler treats as a
  * fresh stack and skips the comparison entirely.  The rest of the packaging
  * lifecycle is unaffected.
+ *
+ * This shim exists because Serverless Framework has no credential-free packaging mode
+ * when custom layers are defined. Tracked upstream:
+ *   https://github.com/serverless/serverless/issues/8187 (root cause, open since 2020)
+ *   https://github.com/serverless/serverless/issues/12969 (feature request for --artifacts-only)
+ * If either issue is resolved, this plugin can be removed.
  */
 class OfflinePackaging {
   constructor(serverless) {

--- a/integration_tests/offline.js
+++ b/integration_tests/offline.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Serverless plugin that intercepts CloudFormation.describeStacks during packaging.
+ *
+ * When custom Lambda layers are defined, Serverless Framework calls
+ * CloudFormation.describeStacks in compareWithLastLayer() to check whether a
+ * layer has already been uploaded (an optimisation to avoid re-uploading
+ * unchanged layers).  The error handler in that function only silences errors
+ * whose message contains "does not exist"; any other error – including the
+ * "The security token included in the request is invalid" response AWS returns
+ * when credentials are absent or invalid – is re-thrown, causing sls package
+ * to fail.
+ *
+ * In snapshot tests we never deploy, so this optimisation is meaningless.
+ * This plugin intercepts the describeStacks call and immediately returns a
+ * synthetic "does not exist" error, which the Serverless handler treats as a
+ * fresh stack and skips the comparison entirely.  The rest of the packaging
+ * lifecycle is unaffected.
+ */
+class OfflinePackaging {
+  constructor(serverless) {
+    this.serverless = serverless;
+    this.hooks = {
+      'before:package:compileLayers': () => this.patchProvider(),
+    };
+  }
+
+  patchProvider() {
+    const provider = this.serverless.getProvider('aws');
+    const original = provider.request.bind(provider);
+    provider.request = (service, method, params, options) => {
+      if (service === 'CloudFormation' && method === 'describeStacks') {
+        const stackName = (params && params.StackName) || 'unknown';
+        return Promise.reject(new Error(`Stack with id ${stackName} does not exist`));
+      }
+      return original(service, method, params, options);
+    };
+  }
+}
+
+module.exports = OfflinePackaging;

--- a/integration_tests/serverless-extension.yml
+++ b/integration_tests/serverless-extension.yml
@@ -3,6 +3,7 @@ frameworkVersion: "3"
 
 plugins:
   - ../dist/src
+  - ./offline
 
 provider:
   name: aws


### PR DESCRIPTION
The entire PR (including the summary below) was generated by Claude Code.

## Problem

The `integration-tests` CI job fails on the first run of every Dependabot PR with:

```
Error:
The security token included in the request is invalid.
```

This happens during `sls package` for `serverless-extension.yml`, but not for `serverless-forwarder.yml`. Dependabot PRs run without valid AWS credentials, which causes `sls package` to fail when it tries to call AWS.

## Root cause

When `serverless.yml` defines a top-level `layers:` section, Serverless Framework v3 calls `CloudFormation.describeStacks` for each layer in `compareWithLastLayer()` (in `lib/plugins/aws/package/compile/layers.js`). This is an optimisation that checks whether a layer has already been uploaded to avoid re-uploading unchanged ones. The error handler in that function only silences errors whose message contains `"does not exist"` — any other AWS error is re-thrown:

```js
(e) => {
    if (e.message.includes('does not exist')) {
        return;
    }
    throw e;  // re-throws "security token invalid" → sls package fails
}
```

The forwarder test is immune because our plugin wraps all CloudWatch calls in a broad `catch` that returns `[]`, silently absorbing credential errors. The extension test has no such safety net.

## Fix

Add a lightweight test-only Serverless plugin (`integration_tests/offline.js`) that hooks into `before:package:compileLayers` and intercepts `CloudFormation.describeStacks` calls, immediately rejecting them with a synthetic `"does not exist"` error. This makes `compareWithLastLayer` treat every snapshot test run as a fresh stack, which is the correct behaviour for snapshot tests where we never actually deploy.

`serverless-extension.yml` is updated to load this plugin.

## How I tested it

**Confirmed the root cause** by running `sls package` locally with placeholder invalid credentials against both configs:
```
# Extension config (before fix) → EXIT: 1
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE AWS_SECRET_ACCESS_KEY=... serverless package --config serverless-extension.yml

# Forwarder config → EXIT: 0 (errors swallowed by plugin)
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE AWS_SECRET_ACCESS_KEY=... serverless package --config serverless-forwarder.yml
```

**Verified the fix** by running the same command after adding `offline.js`:
```
# Extension config (after fix) → EXIT: 0, "Service packaged"
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE AWS_SECRET_ACCESS_KEY=... serverless package --config serverless-extension.yml
```

**Verified snapshot is unchanged** by applying all the normalisation steps from `run_integration_tests.sh` to the generated template and diffing against `correct_extension_snapshot.json` — no differences.

**Cross-referenced with PR history**: PR #666 (a previous Dependabot PR) had the identical failure on its first run and was fixed only by pushing a `run ci` commit to trigger a fresh CI run, confirming this is a consistent first-run issue rather than a one-off flake.