### PR TITLE
chore: add Datadog Code Coverage upload, remove CodeCov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Upload coverage to Datadog
         if: matrix.node-version == 24
+        continue-on-error: true
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        run: npx --yes @datadog/datadog-ci coverage upload --service serverless-plugin-datadog coverage/lcov.info
+          DD_SERVICE: serverless-plugin-datadog
+        run: npx --yes @datadog/datadog-ci coverage upload coverage/lcov.info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,5 +80,8 @@ jobs:
       - name: Run tests
         run: yarn test
 
-      - name: Upload code coverage report
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+      - name: Upload coverage to Datadog
+        if: matrix.node-version == 24
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        run: npx --yes @datadog/datadog-ci coverage upload --service serverless-plugin-datadog coverage/lcov.info


### PR DESCRIPTION
Onboard to Datadog Code Coverage and remove CodeCov upload.

## Summary
- Removes the `codecov/codecov-action` step from the `test` job in `.github/workflows/build.yml`
- Adds a Datadog Code Coverage upload step using `@datadog/datadog-ci` after tests run, gated on `matrix.node-version == 24` to avoid duplicate uploads from the matrix build
- Jest already generates `coverage/lcov.info` via the `lcovonly` reporter in `jest.config.js` — no test command changes needed

## Test plan
- [ ] Confirm `DATADOG_API_KEY` secret is set in the repository settings
- [ ] Verify coverage appears in Datadog Code Coverage for the `serverless-plugin-datadog` service after merging