### PR TITLE
chore: add e2e lambda fixture

### DIFF
--- a/e2e/fixtures/lambda-node/handler.js
+++ b/e2e/fixtures/lambda-node/handler.js
@@ -1,0 +1,16 @@
+// Minimal Node.js workload for the e2e suite. Duplicated from the default
+// handler in serverless-self-monitoring (lambda-managed-instances/handlers/default/nodejs),
+// with one log line added so a log record is emitted on every invocation.
+//
+// No tracer setup lives here on purpose: the serverless-plugin-datadog wiring
+// (Datadog Node layer + extension + redirected handler) auto-instruments the
+// invocation and auto-collects logs. The e2e suite tests that wiring, not the
+// runtime, so this handler stays trivial.
+exports.handler = async function (_event, _context) {
+  console.log(`one-e2e serverless-plugin-datadog lambda invocation service=${process.env.DD_SERVICE}`);
+
+  return {
+    statusCode: 200,
+    body: "hello, world",
+  };
+};

--- a/e2e/fixtures/lambda-node/package.json
+++ b/e2e/fixtures/lambda-node/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "one-e2e-lambda-node-workload",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Ephemeral Lambda workload deployed by the serverless-plugin-datadog e2e suite. The serverless-plugin-datadog dependency is installed from a packed tarball by ../../setup.sh (not listed here, to avoid a recursive file: link).",
+  "dependencies": {
+    "serverless": "3.39.0"
+  }
+}

--- a/e2e/fixtures/lambda-node/serverless.yml
+++ b/e2e/fixtures/lambda-node/serverless.yml
@@ -1,0 +1,49 @@
+# Uninstrumented workload + the serverless-plugin-datadog instrumentation it plugs
+# into. The plugin runs as part of `sls deploy` (APPLY) and is torn down with the
+# whole stack on `sls remove` (REMOVE). Everything that has to be unique or stamped
+# per run is injected via env so this file stays static (see e2e/helpers/naming.ts).
+#
+# frameworkVersion is pinned to 3 to avoid the Serverless Framework v4 login/license
+# flow in CI. The runtime is pinned to one canonical Node.js version (see RULES in
+# the spec: one canonical runtime per platform).
+service: ${env:E2E_SERVICE_NAME}
+
+frameworkVersion: "3"
+
+plugins:
+  - serverless-plugin-datadog
+
+provider:
+  name: aws
+  runtime: nodejs20.x
+  region: ${env:AWS_REGION, "ap-northeast-3"}
+  stage: e2e
+  # Hygiene: freshness tag set atomically at creation, on both the CloudFormation
+  # stack and every resource, so the cross-repo sweeper can age it out.
+  stackTags:
+    one_e2e_created: ${env:E2E_CREATED_TS}
+  tags:
+    one_e2e_created: ${env:E2E_CREATED_TS}
+
+custom:
+  datadog:
+    # API key wiring + site: required for the extension to ship telemetry.
+    apiKey: ${env:DD_API_KEY}
+    site: ${env:DD_SITE, "datadoghq.com"}
+    # Identity: service carries the unique run id, env + version are fixed markers.
+    # These flow onto ingested telemetry and let us assert identity, not existence.
+    service: ${env:E2E_SERVICE_NAME}
+    env: e2e
+    version: "1.0.0"
+    # The mechanism under test: library layer + extension layer + tracing + logs.
+    addLayers: true
+    addExtension: true
+    enableDDTracing: true
+    enableDDLogs: true
+    # Keep the deploy hermetic: no git metadata upload (needs app key + git ctx).
+    enableSourceCodeIntegration: false
+    uploadGitMetadata: false
+
+functions:
+  hello:
+    handler: handler.handler

--- a/e2e/fixtures/lambda-node/serverless.yml
+++ b/e2e/fixtures/lambda-node/serverless.yml
@@ -15,7 +15,7 @@ plugins:
 
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs24.x
   region: ${env:AWS_REGION, "ap-northeast-3"}
   stage: e2e
   # Hygiene: freshness tag set atomically at creation, on both the CloudFormation


### PR DESCRIPTION
Adds the Serverless Framework fixture deployed by the Lambda E2E test:

- a Node.js 24 handler that emits a log line
- Serverless v3 configuration with the plugin's layers, extension, tracing, and logs enabled
- a package manifest that pins the Serverless Framework

The lifecycle test builds and packs the local plugin, then installs that tarball into this fixture.

## Test Plan

Covered by the lifecycle suite in #710.
