### PR TITLE
test: define unsupported runtime boundaries

### DIFF
--- a/src/layer.spec.ts
+++ b/src/layer.spec.ts
@@ -252,6 +252,14 @@ describe("findHandlers", () => {
   });
 });
 
+describe("unsupported runtimes", () => {
+  it.each(["nodejs12.x", "python3.6"])("classifies %s as unsupported", (runtime) => {
+    const service = createMockService("us-east-1", { function: { runtime } });
+
+    expect(findHandlers(service, [])).toEqual([expect.objectContaining({ type: RuntimeType.UNSUPPORTED })]);
+  });
+});
+
 describe("applyLambdaLibraryLayers", () => {
   it("adds a layer array if none are present at the function array or service.provider array", () => {
     const handler = {


### PR DESCRIPTION
### What does this PR do?

Adds coverage for the unsupported runtime boundaries: Node.js 12 and Python 3.6.

### Motivation

Keep automatic instrumentation enabled for newer supported Node.js and Python runtimes.

### Testing Guidelines

No manual validation.

### Additional Notes


### Types of changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
